### PR TITLE
Feature/3 : 엔티티 구현 & 연관관계 매핑

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/admin/domain/Admin.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/domain/Admin.java
@@ -1,10 +1,8 @@
 package com.nexters.dailyphrase.admin.domain;
 
 import com.nexters.dailyphrase.common.domain.BaseDateTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.nexters.dailyphrase.common.enums.MemberRole;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -16,4 +14,13 @@ public class Admin extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String name;
+
+    private String userId;
+
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
 }

--- a/src/main/java/com/nexters/dailyphrase/common/enums/MemberRole.java
+++ b/src/main/java/com/nexters/dailyphrase/common/enums/MemberRole.java
@@ -1,0 +1,14 @@
+package com.nexters.dailyphrase.common.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberRole {
+    ROLE_GUEST("게스트"),
+    ROLE_USER("회원"),
+    ROLE_ADMIN("관리자");
+
+    private final String description;
+}

--- a/src/main/java/com/nexters/dailyphrase/common/enums/SocialType.java
+++ b/src/main/java/com/nexters/dailyphrase/common/enums/SocialType.java
@@ -1,0 +1,21 @@
+package com.nexters.dailyphrase.common.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SocialType {
+    KAKAO("kakao", "카카오"),
+    GOOGLE("google", "구글"),
+    APPLE("apple", "애플");
+
+    private final String value;
+    private final String description;
+
+    @JsonValue
+    String getSocialType() {
+        return this.name().toLowerCase();
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/favorite/domain/Favorite.java
+++ b/src/main/java/com/nexters/dailyphrase/favorite/domain/Favorite.java
@@ -1,10 +1,9 @@
 package com.nexters.dailyphrase.favorite.domain;
 
 import com.nexters.dailyphrase.common.domain.BaseDateTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.nexters.dailyphrase.member.domain.Member;
+import com.nexters.dailyphrase.phrase.domain.Phrase;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -16,4 +15,12 @@ public class Favorite extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Phrase phrase;
 }

--- a/src/main/java/com/nexters/dailyphrase/like/domain/Like.java
+++ b/src/main/java/com/nexters/dailyphrase/like/domain/Like.java
@@ -1,6 +1,8 @@
 package com.nexters.dailyphrase.like.domain;
 
 import com.nexters.dailyphrase.common.domain.BaseDateTimeEntity;
+import com.nexters.dailyphrase.member.domain.Member;
+import com.nexters.dailyphrase.phrase.domain.Phrase;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,4 +16,12 @@ public class Like extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Phrase phrase;
 }

--- a/src/main/java/com/nexters/dailyphrase/member/domain/Member.java
+++ b/src/main/java/com/nexters/dailyphrase/member/domain/Member.java
@@ -1,10 +1,9 @@
 package com.nexters.dailyphrase.member.domain;
 
 import com.nexters.dailyphrase.common.domain.BaseDateTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.nexters.dailyphrase.common.enums.MemberRole;
+import com.nexters.dailyphrase.common.enums.SocialType;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -16,4 +15,14 @@ public class Member extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    private String socialId;
+
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
 }

--- a/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
@@ -16,4 +16,8 @@ public class Phrase extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String title;
+
+    private String content;
 }

--- a/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
@@ -1,10 +1,8 @@
 package com.nexters.dailyphrase.phrase.domain;
 
 import com.nexters.dailyphrase.common.domain.BaseDateTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.nexters.dailyphrase.phraseimage.domain.PhraseImage;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -16,6 +14,9 @@ public class Phrase extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private PhraseImage phraseImage;
 
     private String title;
 

--- a/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
@@ -15,9 +15,6 @@ public class Phrase extends BaseDateTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    private PhraseImage phraseImage;
-
     private String title;
 
     private String content;

--- a/src/main/java/com/nexters/dailyphrase/phraseimage/domain/PhraseImage.java
+++ b/src/main/java/com/nexters/dailyphrase/phraseimage/domain/PhraseImage.java
@@ -1,10 +1,8 @@
 package com.nexters.dailyphrase.phraseimage.domain;
 
 import com.nexters.dailyphrase.common.domain.BaseDateTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.nexters.dailyphrase.phrase.domain.Phrase;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -16,6 +14,10 @@ public class PhraseImage extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @JoinColumn(nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    private Phrase phrase;
 
     private String fileName;
 

--- a/src/main/java/com/nexters/dailyphrase/phraseimage/domain/PhraseImage.java
+++ b/src/main/java/com/nexters/dailyphrase/phraseimage/domain/PhraseImage.java
@@ -16,4 +16,10 @@ public class PhraseImage extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String fileName;
+
+    private String uuid;
+
+    private String url;
 }


### PR DESCRIPTION
## 🚀 개요
https://github.com/Nexters/daily-phrase-server/issues/3
함께 설계한 ERD를 바탕으로 엔티티의 필드들을 채우고, 엔티티 연관관계를 매핑했습니다.
하나의 글귀에 여러 이미지가 첨부될 수 있는 미래의 요구사항을 고려하여
Phrase 쪽에 있던 phrase_image_id 외래키대신 PhraseImage 쪽에 phrase_id 외래키를 두었습니다.

## 🔍 작업 내용
- 엔티티 구현
- 연관관계 매핑

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

