### PR TITLE
Feature/7 : 예외 처리 설계

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/common/consts/DailyPhraseStatic.java
+++ b/src/main/java/com/nexters/dailyphrase/common/consts/DailyPhraseStatic.java
@@ -1,0 +1,23 @@
+package com.nexters.dailyphrase.common.consts;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DailyPhraseStatic {
+    public static final String AUTH_HEADER = "Authorization";
+    public static final String BEARER = "Bearer ";
+    public static final String WITHDRAW_PREFIX = "DELETED:";
+    public static final String TOKEN_ROLE = "role";
+    public static final String TOKEN_TYPE = "type";
+    public static final String TOKEN_ISSUER = "DailyPhrase";
+    public static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+    public static final String REFRESH_TOKEN = "REFRESH_TOKEN";
+
+    public static final int MILLI_TO_SECOND = 1000;
+    public static final int BAD_REQUEST = 400;
+    public static final int UNAUTHORIZED = 401;
+    public static final int FORBIDDEN = 403;
+    public static final int NOT_FOUND = 404;
+    public static final int INTERNAL_SERVER = 500;
+}

--- a/src/main/java/com/nexters/dailyphrase/common/exception/BaseCodeException.java
+++ b/src/main/java/com/nexters/dailyphrase/common/exception/BaseCodeException.java
@@ -1,0 +1,14 @@
+package com.nexters.dailyphrase.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BaseCodeException extends RuntimeException {
+    private final BaseErrorCode errorCode;
+
+    public ErrorReason getErrorReason() {
+        return this.errorCode.getErrorReason();
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/common/exception/BaseDynamicException.java
+++ b/src/main/java/com/nexters/dailyphrase/common/exception/BaseDynamicException.java
@@ -1,0 +1,12 @@
+package com.nexters.dailyphrase.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BaseDynamicException extends RuntimeException {
+    private final int status;
+    private final String code;
+    private final String reason;
+}

--- a/src/main/java/com/nexters/dailyphrase/common/exception/BaseErrorCode.java
+++ b/src/main/java/com/nexters/dailyphrase/common/exception/BaseErrorCode.java
@@ -1,0 +1,5 @@
+package com.nexters.dailyphrase.common.exception;
+
+public interface BaseErrorCode {
+    public ErrorReason getErrorReason();
+}

--- a/src/main/java/com/nexters/dailyphrase/common/exception/ErrorReason.java
+++ b/src/main/java/com/nexters/dailyphrase/common/exception/ErrorReason.java
@@ -1,0 +1,12 @@
+package com.nexters.dailyphrase.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorReason {
+    private final Integer status;
+    private final String code;
+    private final String reason;
+}

--- a/src/main/java/com/nexters/dailyphrase/common/exception/GlobalErrorCode.java
+++ b/src/main/java/com/nexters/dailyphrase/common/exception/GlobalErrorCode.java
@@ -1,0 +1,39 @@
+package com.nexters.dailyphrase.common.exception;
+
+import static com.nexters.dailyphrase.common.consts.DailyPhraseStatic.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements BaseErrorCode {
+    ARGUMENT_NOT_VALID_ERROR(BAD_REQUEST, "GLOBAL_400_1", "검증 오류"),
+
+    TOKEN_EXPIRED(UNAUTHORIZED, "AUTH_401_1", "인증 시간이 만료되었습니다. 인증토큰을 재 발급 해주세요"),
+    REFRESH_TOKEN_EXPIRED(FORBIDDEN, "AUTH_403_1", "인증 시간이 만료되었습니다. 재 로그인 해주세요."),
+    ACCESS_TOKEN_NOT_EXIST(FORBIDDEN, "AUTH_403_2", "알맞은 accessToken을 넣어주세요."),
+    INVALID_TOKEN(UNAUTHORIZED, "GLOBAL_401_1", "잘못된 토큰입니다. 재 로그인 해주세요"),
+    INTERNAL_SERVER_ERROR(INTERNAL_SERVER, "GLOBAL_500_1", "서버 오류. 관리자에게 문의 부탁드립니다."),
+
+    OTHER_SERVER_BAD_REQUEST(BAD_REQUEST, "FEIGN_400_1", "Other server bad request"),
+    OTHER_SERVER_UNAUTHORIZED(BAD_REQUEST, "FEIGN_400_2", "Other server unauthorized"),
+    OTHER_SERVER_FORBIDDEN(BAD_REQUEST, "FEIGN_400_3", "Other server forbidden"),
+    OTHER_SERVER_EXPIRED_TOKEN(BAD_REQUEST, "FEIGN_400_4", "Other server expired token"),
+    OTHER_SERVER_NOT_FOUND(BAD_REQUEST, "FEIGN_400_5", "Other server not found error"),
+    OTHER_SERVER_INTERNAL_SERVER_ERROR(
+            BAD_REQUEST, "FEIGN_400_6", "Other server internal server error"),
+    SECURITY_CONTEXT_NOT_FOUND(500, "GLOBAL_500_2", "security context not found"),
+
+    BAD_FILE_EXTENSION(BAD_REQUEST, "FILE_400_1", "파일 확장자가 잘못 되었습니다."),
+    TOO_MANY_REQUEST(429, "GLOBAL_429_1", "과도한 요청을 보내셨습니다. 잠시 기다려 주세요.");
+
+    private final Integer status;
+    private final String code;
+    private final String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.builder().reason(reason).code(code).status(status).build();
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/nexters/dailyphrase/common/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,168 @@
+package com.nexters.dailyphrase.common.exception.handler;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.lang.Nullable;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.dailyphrase.common.exception.*;
+import com.nexters.dailyphrase.common.presentation.ErrorResponse;
+
+import lombok.SneakyThrows;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception ex,
+            @Nullable Object body,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        ServletWebRequest servletWebRequest = (ServletWebRequest) request;
+        String url =
+                UriComponentsBuilder.fromHttpRequest(
+                                new ServletServerHttpRequest(servletWebRequest.getRequest()))
+                        .build()
+                        .toUriString();
+
+        ErrorResponse errorResponse =
+                new ErrorResponse(
+                        status.value(),
+                        HttpStatus.valueOf(status.value()).name(),
+                        ex.getMessage(),
+                        url);
+        return super.handleExceptionInternal(ex, errorResponse, headers, status, request);
+    }
+
+    @SneakyThrows
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+
+        List<FieldError> errors = ex.getBindingResult().getFieldErrors();
+        ServletWebRequest servletWebRequest = (ServletWebRequest) request;
+        String url =
+                UriComponentsBuilder.fromHttpRequest(
+                                new ServletServerHttpRequest(servletWebRequest.getRequest()))
+                        .build()
+                        .toUriString();
+        Map<String, Object> fieldAndErrorMessages =
+                errors.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        FieldError::getField, FieldError::getDefaultMessage));
+
+        String errorsToJsonString = new ObjectMapper().writeValueAsString(fieldAndErrorMessages);
+        ErrorResponse errorResponse =
+                new ErrorResponse(
+                        status.value(),
+                        HttpStatus.valueOf(status.value()).name(),
+                        errorsToJsonString,
+                        url);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> constraintViolationExceptionHandler(
+            ConstraintViolationException e, HttpServletRequest request) {
+        Map<String, Object> bindingErrors = new HashMap<>();
+        e.getConstraintViolations()
+                .forEach(
+                        constraintViolation -> {
+                            List<String> propertyPath =
+                                    List.of(
+                                            constraintViolation
+                                                    .getPropertyPath()
+                                                    .toString()
+                                                    .split("\\."));
+                            String path =
+                                    propertyPath.stream()
+                                            .skip(propertyPath.size() - 1L)
+                                            .findFirst()
+                                            .orElse(null);
+                            bindingErrors.put(path, constraintViolation.getMessage());
+                        });
+
+        ErrorReason errorReason =
+                ErrorReason.builder()
+                        .code("BAD_REQUEST")
+                        .status(400)
+                        .reason(bindingErrors.toString())
+                        .build();
+        ErrorResponse errorResponse =
+                new ErrorResponse(errorReason, request.getRequestURL().toString());
+        return ResponseEntity.status(HttpStatus.valueOf(errorReason.getStatus()))
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(BaseCodeException.class)
+    public ResponseEntity<ErrorResponse> baseCodeExceptionHandler(
+            BaseCodeException e, HttpServletRequest request) {
+        BaseErrorCode code = e.getErrorCode();
+
+        ErrorReason errorReason = code.getErrorReason();
+        ErrorResponse errorResponse =
+                new ErrorResponse(errorReason, request.getRequestURL().toString());
+        return ResponseEntity.status(HttpStatus.valueOf(errorReason.getStatus()))
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(BaseDynamicException.class)
+    public ResponseEntity<ErrorResponse> baseDynamicExceptionHandler(
+            BaseDynamicException e, HttpServletRequest request) {
+        ErrorResponse errorResponse =
+                new ErrorResponse(
+                        e.getStatus(),
+                        e.getCode(),
+                        e.getReason(),
+                        request.getRequestURL().toString());
+        return ResponseEntity.status(HttpStatus.valueOf(e.getStatus())).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request)
+            throws IOException {
+        String url =
+                UriComponentsBuilder.fromHttpRequest(new ServletServerHttpRequest(request))
+                        .build()
+                        .toUriString();
+
+        //        log.error("INTERNAL_SERVER_ERROR", e);
+        GlobalErrorCode internalServerError = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+        ErrorResponse errorResponse =
+                new ErrorResponse(
+                        internalServerError.getStatus(),
+                        internalServerError.getCode(),
+                        internalServerError.getReason(),
+                        url);
+
+        return ResponseEntity.status(HttpStatus.valueOf(internalServerError.getStatus()))
+                .body(errorResponse);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/common/presentation/CommonResponse.java
+++ b/src/main/java/com/nexters/dailyphrase/common/presentation/CommonResponse.java
@@ -26,7 +26,7 @@ public class CommonResponse<T> {
     private T result;
 
     public static <T> CommonResponse<T> onSuccess(T data) {
-        return new CommonResponse<>(true, "요청에 성공하였습니다.", "1000", data);
+        return new CommonResponse<>(true, "1000", "요청에 성공하였습니다.", data);
     }
 
     public static <T> CommonResponse<T> onFailure(String code, String message, T data) {

--- a/src/main/java/com/nexters/dailyphrase/common/presentation/ErrorResponse.java
+++ b/src/main/java/com/nexters/dailyphrase/common/presentation/ErrorResponse.java
@@ -1,0 +1,35 @@
+package com.nexters.dailyphrase.common.presentation;
+
+import java.time.LocalDateTime;
+
+import com.nexters.dailyphrase.common.exception.ErrorReason;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+    private final boolean isSuccess = false;
+    private final int status;
+    private final String code;
+    private final String message;
+    private final LocalDateTime timeStamp;
+
+    private final String path;
+
+    public ErrorResponse(ErrorReason errorReason, String path) {
+        this.status = errorReason.getStatus();
+        this.code = errorReason.getCode();
+        this.message = errorReason.getReason();
+        this.timeStamp = LocalDateTime.now();
+        this.path = path;
+    }
+
+    public ErrorResponse(int status, String code, String reason, String path) {
+        this.status = status;
+        this.code = code;
+        this.message = reason;
+        this.timeStamp = LocalDateTime.now();
+        this.path = path;
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/common/presentation/ErrorResponse.java
+++ b/src/main/java/com/nexters/dailyphrase/common/presentation/ErrorResponse.java
@@ -14,7 +14,6 @@ public class ErrorResponse {
     private final String code;
     private final String message;
     private final LocalDateTime timeStamp;
-
     private final String path;
 
     public ErrorResponse(ErrorReason errorReason, String path) {

--- a/src/main/java/com/nexters/dailyphrase/phrase/exception/PhraseErrorCode.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/exception/PhraseErrorCode.java
@@ -1,0 +1,23 @@
+package com.nexters.dailyphrase.phrase.exception;
+
+import com.nexters.dailyphrase.common.exception.BaseErrorCode;
+import com.nexters.dailyphrase.common.exception.ErrorReason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.nexters.dailyphrase.common.consts.DailyPhraseStatic.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum PhraseErrorCode implements BaseErrorCode {
+    PHRASE_NOT_FOUND(NOT_FOUND, "PHRASE_404_1", "글귀를 찾을 수 없습니다.");
+
+    private final Integer status;
+    private final String code;
+    private final String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.builder().reason(reason).code(code).status(status).build();
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/phrase/exception/PhraseNotFoundException.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/exception/PhraseNotFoundException.java
@@ -1,0 +1,11 @@
+package com.nexters.dailyphrase.phrase.exception;
+
+import com.nexters.dailyphrase.common.exception.BaseCodeException;
+
+public class PhraseNotFoundException extends BaseCodeException {
+    public static BaseCodeException EXCEPTION = new PhraseNotFoundException();
+
+    private PhraseNotFoundException() {
+        super(PhraseErrorCode.PHRASE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/phrase/implement/PhraseQueryService.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/implement/PhraseQueryService.java
@@ -1,5 +1,7 @@
 package com.nexters.dailyphrase.phrase.implement;
 
+import com.nexters.dailyphrase.phrase.domain.Phrase;
+import com.nexters.dailyphrase.phrase.exception.PhraseNotFoundException;
 import org.springframework.stereotype.Service;
 
 import com.nexters.dailyphrase.phrase.domain.repository.PhraseRepository;
@@ -10,4 +12,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PhraseQueryService {
     private final PhraseRepository phraseRepository;
+
+    public Phrase findById(Long id) {
+        return phraseRepository.findById(id)
+                .orElseThrow(() -> PhraseNotFoundException.EXCEPTION);
+    }
 }


### PR DESCRIPTION
## 🚀 개요
### 코드 예외 설계
<img src="https://github.com/Nexters/daily-phrase-server/assets/53550707/5e1cc1c6-fefe-4953-b2e4-24fd1c4a25e0" width="60%"/>

- 코드 예외는 RuntimeException을 상속하는 BaseCodeException을 만들어두고, 필요한 예외별로 해당 예외를 상속해서 사용하도록 구현했습니다.
- 외부 API 호출 등 직접 예외를 정의하기 번거로울 때, 던질 수 있는 BaseDynamicException을 만들었습니다.
- 에러 응답 생성시 편리를 위해 ErrorReason 클래스를 따로 두었습니다.

### 에러 코드 관리
<img src="https://github.com/Nexters/daily-phrase-server/assets/53550707/5f172132-9603-40f3-bb0c-52d9ad5fb2b2" width="60%"/>

- 도메인 별로 에러 코드를 관리하도록 설계했습니다.

### 예외 응답
- CommonResponse에서 data를 제외하고 status, timestamp, path를 추가한 ErrorResponse를 만들어두었습니다.
- 전역 예외 핸들러를 만들어서 한 곳에서 예외를 핸들링합니다. (GlobalExceptionHandler)


## 🔍 작업 내용
- 전역 예외 핸들러
- 코드 예외 클래스
- 도메인별 에러 코드

## 📝 논의사항
스웨거 예외 문서화는 나중에 다른 이슈로 다루겠습니다!

