### PR TITLE
Feature/12 : 글귀 상세 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/com/nexters/dailyphrase/common/presentation/ErrorResponse.java
+++ b/src/main/java/com/nexters/dailyphrase/common/presentation/ErrorResponse.java
@@ -2,14 +2,19 @@ package com.nexters.dailyphrase.common.presentation;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.nexters.dailyphrase.common.exception.ErrorReason;
 
 import lombok.Getter;
 
 @Getter
+@JsonPropertyOrder({"isSuccess", "code", "message", "status", "timeStamp", "path"})
 public class ErrorResponse {
 
-    private final boolean isSuccess = false;
+    @JsonProperty("isSuccess")
+    private final boolean success;
+
     private final int status;
     private final String code;
     private final String message;
@@ -17,6 +22,7 @@ public class ErrorResponse {
     private final String path;
 
     public ErrorResponse(ErrorReason errorReason, String path) {
+        this.success = false;
         this.status = errorReason.getStatus();
         this.code = errorReason.getCode();
         this.message = errorReason.getReason();
@@ -25,6 +31,7 @@ public class ErrorResponse {
     }
 
     public ErrorResponse(int status, String code, String reason, String path) {
+        this.success = false;
         this.status = status;
         this.code = code;
         this.message = reason;

--- a/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseFacade.java
@@ -1,9 +1,12 @@
 package com.nexters.dailyphrase.phrase.business;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.nexters.dailyphrase.phrase.domain.Phrase;
 import com.nexters.dailyphrase.phrase.implement.PhraseCommandService;
 import com.nexters.dailyphrase.phrase.implement.PhraseQueryService;
+import com.nexters.dailyphrase.phrase.presentation.dto.PhraseResponseDTO;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +15,12 @@ import lombok.RequiredArgsConstructor;
 public class PhraseFacade {
     private final PhraseQueryService phraseQueryService;
     private final PhraseCommandService phraseCommandService;
+    private final PhraseMapper phraseMapper;
+
+    @Transactional
+    public PhraseResponseDTO.PhraseDetail getPhraseDetail(Long id) {
+        phraseCommandService.increaseViewCountById(id);
+        Phrase phrase = phraseQueryService.findById(id);
+        return phraseMapper.toPhraseDetail(phrase);
+    }
 }

--- a/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseMapper.java
@@ -1,0 +1,27 @@
+package com.nexters.dailyphrase.phrase.business;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.nexters.dailyphrase.phrase.domain.Phrase;
+import com.nexters.dailyphrase.phrase.presentation.dto.PhraseResponseDTO;
+import com.nexters.dailyphrase.phraseimage.domain.PhraseImage;
+
+@Component
+public class PhraseMapper {
+
+    public PhraseResponseDTO.PhraseDetail toPhraseDetail(Phrase phrase) {
+        String imageUrl =
+                Optional.ofNullable(phrase.getPhraseImage())
+                        .map(PhraseImage::getUrl)
+                        .orElse(""); // 또는 기본값 사용
+
+        return PhraseResponseDTO.PhraseDetail.builder()
+                .title(phrase.getTitle())
+                .imageUrl(imageUrl)
+                .content(phrase.getContent())
+                .viewCount(phrase.getViewCount())
+                .build();
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
@@ -1,9 +1,9 @@
 package com.nexters.dailyphrase.phrase.domain;
 
-import com.nexters.dailyphrase.phraseimage.domain.PhraseImage;
 import jakarta.persistence.*;
 
 import com.nexters.dailyphrase.common.domain.BaseDateTimeEntity;
+import com.nexters.dailyphrase.phraseimage.domain.PhraseImage;
 
 import lombok.*;
 
@@ -21,8 +21,7 @@ public class Phrase extends BaseDateTimeEntity {
 
     private String content;
 
-    @Builder.Default
-    private int viewCount = 0;
+    @Builder.Default private int viewCount = 0;
 
     @OneToOne(mappedBy = "phrase", cascade = CascadeType.REMOVE)
     private PhraseImage phraseImage;

--- a/src/main/java/com/nexters/dailyphrase/phrase/domain/repository/PhraseRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/domain/repository/PhraseRepository.java
@@ -1,7 +1,19 @@
 package com.nexters.dailyphrase.phrase.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.nexters.dailyphrase.phrase.domain.Phrase;
 
-public interface PhraseRepository extends JpaRepository<Phrase, Long> {}
+public interface PhraseRepository extends JpaRepository<Phrase, Long> {
+
+    @Query("select p from Phrase p left join fetch p.phraseImage where p.id = :phraseId")
+    Optional<Phrase> findById(Long phraseId);
+
+    @Modifying
+    @Query("update Phrase p set p.viewCount = p.viewCount + 1 where p.id = :phraseId")
+    void updateViewCountById(Long phraseId);
+}

--- a/src/main/java/com/nexters/dailyphrase/phrase/exception/PhraseErrorCode.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/exception/PhraseErrorCode.java
@@ -1,11 +1,12 @@
 package com.nexters.dailyphrase.phrase.exception;
 
+import static com.nexters.dailyphrase.common.consts.DailyPhraseStatic.NOT_FOUND;
+
 import com.nexters.dailyphrase.common.exception.BaseErrorCode;
 import com.nexters.dailyphrase.common.exception.ErrorReason;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import static com.nexters.dailyphrase.common.consts.DailyPhraseStatic.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/nexters/dailyphrase/phrase/implement/PhraseCommandService.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/implement/PhraseCommandService.java
@@ -10,4 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PhraseCommandService {
     private final PhraseRepository phraseRepository;
+
+    public void increaseViewCountById(Long phraseId) {
+        phraseRepository.updateViewCountById(phraseId);
+    }
 }

--- a/src/main/java/com/nexters/dailyphrase/phrase/implement/PhraseQueryService.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/implement/PhraseQueryService.java
@@ -1,10 +1,10 @@
 package com.nexters.dailyphrase.phrase.implement;
 
-import com.nexters.dailyphrase.phrase.domain.Phrase;
-import com.nexters.dailyphrase.phrase.exception.PhraseNotFoundException;
 import org.springframework.stereotype.Service;
 
+import com.nexters.dailyphrase.phrase.domain.Phrase;
 import com.nexters.dailyphrase.phrase.domain.repository.PhraseRepository;
+import com.nexters.dailyphrase.phrase.exception.PhraseNotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,7 +14,6 @@ public class PhraseQueryService {
     private final PhraseRepository phraseRepository;
 
     public Phrase findById(Long id) {
-        return phraseRepository.findById(id)
-                .orElseThrow(() -> PhraseNotFoundException.EXCEPTION);
+        return phraseRepository.findById(id).orElseThrow(() -> PhraseNotFoundException.EXCEPTION);
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/phrase/presentation/PhraseApi.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/presentation/PhraseApi.java
@@ -25,6 +25,6 @@ public class PhraseApi {
     @GetMapping("/{id}")
     public CommonResponse<PhraseResponseDTO.PhraseDetail> getPhraseDetail(
             @PathVariable final Long id) {
-        return null;
+        return CommonResponse.onSuccess(phraseFacade.getPhraseDetail(id));
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/phrase/presentation/dto/PhraseResponseDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/presentation/dto/PhraseResponseDTO.java
@@ -10,7 +10,10 @@ public class PhraseResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class PhraseDetail {
-        private String field;
+        private String title;
+        private String imageUrl;
+        private String content;
+        private int viewCount;
     }
 
     @Builder

--- a/src/main/java/com/nexters/dailyphrase/phraseimage/domain/PhraseImage.java
+++ b/src/main/java/com/nexters/dailyphrase/phraseimage/domain/PhraseImage.java
@@ -25,6 +25,7 @@ public class PhraseImage extends BaseDateTimeEntity {
 
     private String uuid;
 
+    @Column(length = 1000)
     private String url;
 
     public void setPhrase(Phrase phrase) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,23 @@ spring:
           auto: update
         default_batch_fetch_size: 1000
 ---
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        ddl-hbm2ddl:
+          auto: create
+#        show_sql: true
+#        format_sql: true
+#        use_sql_comments: true
+        default_batch_fetch_size: 1000
+

--- a/src/test/java/com/nexters/dailyphrase/phrase/business/PhraseFacadeIntegrationTest.java
+++ b/src/test/java/com/nexters/dailyphrase/phrase/business/PhraseFacadeIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.nexters.dailyphrase.phrase.business;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nexters.dailyphrase.phrase.domain.Phrase;
+import com.nexters.dailyphrase.phrase.domain.repository.PhraseRepository;
+import com.nexters.dailyphrase.phrase.presentation.dto.PhraseResponseDTO;
+import com.nexters.dailyphrase.phraseimage.domain.PhraseImage;
+import com.nexters.dailyphrase.phraseimage.domain.repository.PhraseImageRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PhraseFacadeIntegrationTest {
+
+    @Autowired private PhraseFacade phraseFacade;
+    @Autowired private PhraseRepository phraseRepository;
+    @Autowired private PhraseImageRepository phraseImageRepository;
+
+    final String title = "제목입니다.";
+    final String content = "내용입니다.";
+    final String imageUrl =
+            "https://images.unsplash.com/photo-1496181133206-80ce9b88a853?q=80&w=3542&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
+    final String fileName = "laptop";
+    final String uuid = "550e8400-e29b-41d4-a716-446655440000";
+
+    @Test
+    @DisplayName("글귀 상세조회 로직을 테스트합니다.")
+    void 글귀_상세조회() {
+        // given
+        Phrase phrase = Phrase.builder().title(title).content(content).build();
+        phrase = phraseRepository.save(phrase);
+        Long phraseId = phrase.getId();
+
+        PhraseImage phraseImage =
+                PhraseImage.builder().url(imageUrl).fileName(fileName).uuid(uuid).build();
+        phraseImage.setPhrase(phrase);
+        phraseImageRepository.save(phraseImage);
+
+        // when
+        PhraseResponseDTO.PhraseDetail phraseDetail = phraseFacade.getPhraseDetail(phraseId);
+
+        // then
+        assertEquals(title, phraseDetail.getTitle());
+        assertEquals(content, phraseDetail.getContent());
+        assertEquals(1, phraseDetail.getViewCount());
+        assertEquals(imageUrl, phraseDetail.getImageUrl());
+    }
+
+    @Test
+    @DisplayName("100명이 동시에 조회하면 100의 조회수가 늘어나야 합니다.")
+    void 글귀_상세조회_동시요청() throws InterruptedException {
+        // given
+        final int numberOfThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        Phrase phrase = Phrase.builder().title(title).content(content).build();
+        phrase = phraseRepository.save(phrase);
+        Long phraseId = phrase.getId();
+
+        // when
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.execute(
+                    () -> {
+                        try {
+                            phraseFacade.getPhraseDetail(phraseId);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        Phrase updatedPhrase = phraseRepository.findById(phraseId).orElseThrow();
+        assertEquals(numberOfThreads, updatedPhrase.getViewCount());
+    }
+}


### PR DESCRIPTION
## 🚀 개요
글귀 상세 조회 API를 구현했습니다.

## 🔍 작업 내용
- **GET** /v1/phrases/{id} 글귀 상세 조회
- 테스트용 Profile을 추가했습니다. 
    - 테스트 클래스 상단에서 `@ActiveProfiles("test")`을 사용하면 됩니다.
    - H2 DB를 사용하도록 구성했습니다.
- PhraseImage 테이블의 url 필드 길이를 1000자로 확대했습니다.

## 📝 논의사항
- 조회수 중복 증가 방지는 현재 크게 관심 둘 부분이 아닌 것 같아서 추후 고도화를 하게 되면 이슈로 가져가겠습니다.
- 동시 요청에 대해서는 조회수가 정상적으로 증가하도록 구현했습니다.
