### PR TITLE
Feature/13 : 카카오 로그인 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'io.github.openfeign:feign-jackson:12.1'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'io.github.openfeign:feign-jackson:12.1'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/nexters/dailyphrase/common/enums/SocialType.java
+++ b/src/main/java/com/nexters/dailyphrase/common/enums/SocialType.java
@@ -8,9 +8,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum SocialType {
-    KAKAO("kakao", "카카오"),
-    GOOGLE("google", "구글"),
-    APPLE("apple", "애플");
+    KAKAO("kakao", "카카오");
 
     private final String value;
     private final String description;

--- a/src/main/java/com/nexters/dailyphrase/common/exception/ExpiredTokenException.java
+++ b/src/main/java/com/nexters/dailyphrase/common/exception/ExpiredTokenException.java
@@ -1,0 +1,9 @@
+package com.nexters.dailyphrase.common.exception;
+
+public class ExpiredTokenException extends BaseCodeException {
+    public static final BaseCodeException EXCEPTION = new ExpiredTokenException();
+
+    private ExpiredTokenException() {
+        super(GlobalErrorCode.TOKEN_EXPIRED);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/common/exception/InvalidTokenException.java
+++ b/src/main/java/com/nexters/dailyphrase/common/exception/InvalidTokenException.java
@@ -1,0 +1,9 @@
+package com.nexters.dailyphrase.common.exception;
+
+public class InvalidTokenException extends BaseCodeException {
+    public static final BaseCodeException EXCEPTION = new InvalidTokenException();
+
+    private InvalidTokenException() {
+        super(GlobalErrorCode.INVALID_TOKEN);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/common/exception/RefreshTokenExpiredException.java
+++ b/src/main/java/com/nexters/dailyphrase/common/exception/RefreshTokenExpiredException.java
@@ -1,0 +1,9 @@
+package com.nexters.dailyphrase.common.exception;
+
+public class RefreshTokenExpiredException extends BaseCodeException {
+    public static final BaseCodeException EXCEPTION = new RefreshTokenExpiredException();
+
+    private RefreshTokenExpiredException() {
+        super(GlobalErrorCode.REFRESH_TOKEN_EXPIRED);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/common/jwt/JwtProperties.java
+++ b/src/main/java/com/nexters/dailyphrase/common/jwt/JwtProperties.java
@@ -1,0 +1,20 @@
+package com.nexters.dailyphrase.common.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+
+@Getter
+@ConfigurationProperties(prefix = "auth.jwt")
+public class JwtProperties {
+
+    private final String secretKey;
+    private final long accessExp;
+    private final long refreshExp;
+
+    public JwtProperties(String secretKey, long accessExp, long refreshExp) {
+        this.secretKey = secretKey;
+        this.accessExp = accessExp;
+        this.refreshExp = refreshExp;
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/common/jwt/JwtTokenService.java
+++ b/src/main/java/com/nexters/dailyphrase/common/jwt/JwtTokenService.java
@@ -1,0 +1,122 @@
+package com.nexters.dailyphrase.common.jwt;
+
+import static com.nexters.dailyphrase.common.consts.DailyPhraseStatic.*;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.stereotype.Component;
+
+import com.nexters.dailyphrase.common.exception.ExpiredTokenException;
+import com.nexters.dailyphrase.common.exception.InvalidTokenException;
+import com.nexters.dailyphrase.common.exception.RefreshTokenExpiredException;
+import com.nexters.dailyphrase.common.jwt.dto.AccessTokenInfo;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class JwtTokenService {
+
+    private final JwtProperties jwtProperties;
+
+    private Jws<Claims> getJws(String token) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(getSecretKey()).build().parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw ExpiredTokenException.EXCEPTION;
+        } catch (Exception e) {
+            throw InvalidTokenException.EXCEPTION;
+        }
+    }
+
+    private Key getSecretKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String buildAccessToken(
+            Long id, Date issuedAt, Date accessTokenExpiresIn, String role) {
+        final Key encodedKey = getSecretKey();
+        return Jwts.builder()
+                .setIssuer(TOKEN_ISSUER)
+                .setIssuedAt(issuedAt)
+                .setSubject(id.toString())
+                .claim(TOKEN_TYPE, ACCESS_TOKEN)
+                .claim(TOKEN_ROLE, role)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(encodedKey)
+                .compact();
+    }
+
+    private String buildRefreshToken(Long id, Date issuedAt, Date accessTokenExpiresIn) {
+        final Key encodedKey = getSecretKey();
+        return Jwts.builder()
+                .setIssuer(TOKEN_ISSUER)
+                .setIssuedAt(issuedAt)
+                .setSubject(id.toString())
+                .claim(TOKEN_TYPE, REFRESH_TOKEN)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(encodedKey)
+                .compact();
+    }
+
+    public String generateAccessToken(Long id, String role) {
+        final Date issuedAt = new Date();
+        final Date accessTokenExpiresIn =
+                new Date(issuedAt.getTime() + jwtProperties.getAccessExp() * MILLI_TO_SECOND);
+
+        return buildAccessToken(id, issuedAt, accessTokenExpiresIn, role);
+    }
+
+    public String generateRefreshToken(Long id) {
+        final Date issuedAt = new Date();
+        final Date refreshTokenExpiresIn =
+                new Date(issuedAt.getTime() + jwtProperties.getRefreshExp() * MILLI_TO_SECOND);
+        return buildRefreshToken(id, issuedAt, refreshTokenExpiresIn);
+    }
+
+    public boolean isAccessToken(String token) {
+        return getJws(token).getBody().get(TOKEN_TYPE).equals(ACCESS_TOKEN);
+    }
+
+    public boolean isRefreshToken(String token) {
+        return getJws(token).getBody().get(TOKEN_TYPE).equals(REFRESH_TOKEN);
+    }
+
+    public AccessTokenInfo parseAccessToken(String token) {
+        if (isAccessToken(token)) {
+            Claims claims = getJws(token).getBody();
+            return AccessTokenInfo.builder()
+                    .userId(Long.parseLong(claims.getSubject()))
+                    .role((String) claims.get(TOKEN_ROLE))
+                    .build();
+        }
+        throw InvalidTokenException.EXCEPTION;
+    }
+
+    public Long parseRefreshToken(String token) {
+        try {
+            if (isRefreshToken(token)) {
+                Claims claims = getJws(token).getBody();
+                return Long.parseLong(claims.getSubject());
+            }
+        } catch (ExpiredTokenException e) {
+            throw RefreshTokenExpiredException.EXCEPTION;
+        }
+        throw InvalidTokenException.EXCEPTION;
+    }
+
+    public Long getRefreshTokenTTlSecond() {
+        return jwtProperties.getRefreshExp();
+    }
+
+    public Long getAccessTokenTTlSecond() {
+        return jwtProperties.getAccessExp();
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/common/jwt/dto/AccessTokenInfo.java
+++ b/src/main/java/com/nexters/dailyphrase/common/jwt/dto/AccessTokenInfo.java
@@ -1,0 +1,11 @@
+package com.nexters.dailyphrase.common.jwt.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AccessTokenInfo {
+    private final Long userId;
+    private final String role;
+}

--- a/src/main/java/com/nexters/dailyphrase/config/ConfigurationPropertiesConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/ConfigurationPropertiesConfig.java
@@ -1,0 +1,12 @@
+package com.nexters.dailyphrase.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import com.nexters.dailyphrase.common.jwt.JwtProperties;
+
+@EnableConfigurationProperties({
+    JwtProperties.class,
+})
+@Configuration
+public class ConfigurationPropertiesConfig {}

--- a/src/main/java/com/nexters/dailyphrase/config/FeignCommonConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/FeignCommonConfig.java
@@ -1,0 +1,43 @@
+package com.nexters.dailyphrase.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nexters.dailyphrase.infra.feign.BaseFeignClientPackage;
+
+import feign.Logger.Level;
+import feign.codec.Decoder;
+import feign.jackson.JacksonDecoder;
+
+@Configuration
+@EnableFeignClients(basePackageClasses = {BaseFeignClientPackage.class})
+public class FeignCommonConfig {
+    @Bean
+    public Decoder feignDecoder() {
+        return new JacksonDecoder(customObjectMapper());
+    }
+
+    /**
+     * 타임관련 유닛 해석을 위한 디코더 추가
+     *
+     * @return
+     */
+    public ObjectMapper customObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false);
+        return objectMapper;
+    }
+
+    @Bean
+    Level feignLoggerLevel() {
+        return Level.FULL;
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/config/JpaAuditingConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/JpaAuditingConfig.java
@@ -1,0 +1,8 @@
+package com.nexters.dailyphrase.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {}

--- a/src/main/java/com/nexters/dailyphrase/infra/feign/BaseFeignClientPackage.java
+++ b/src/main/java/com/nexters/dailyphrase/infra/feign/BaseFeignClientPackage.java
@@ -1,0 +1,3 @@
+package com.nexters.dailyphrase.infra.feign;
+
+public interface BaseFeignClientPackage {}

--- a/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/client/KakaoLoginFeignClient.java
+++ b/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/client/KakaoLoginFeignClient.java
@@ -1,0 +1,20 @@
+package com.nexters.dailyphrase.infra.feign.kakao.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import com.nexters.dailyphrase.infra.feign.kakao.config.KakaoLoginConfig;
+import com.nexters.dailyphrase.infra.feign.kakao.dto.KakaoLoginUserDTO;
+
+@FeignClient(
+        name = "KakaoInfoClient",
+        url = "https://kapi.kakao.com",
+        configuration = KakaoLoginConfig.class)
+@Component
+// Token을 가지고 회원정보를 요청하는 Feign이다.
+public interface KakaoLoginFeignClient {
+    @GetMapping("/v2/user/me")
+    KakaoLoginUserDTO getInfo(@RequestHeader(name = "Authorization") String Authorization);
+}

--- a/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/client/KakaoLoginFeignClient.java
+++ b/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/client/KakaoLoginFeignClient.java
@@ -9,12 +9,11 @@ import com.nexters.dailyphrase.infra.feign.kakao.config.KakaoLoginConfig;
 import com.nexters.dailyphrase.infra.feign.kakao.dto.KakaoLoginUserDTO;
 
 @FeignClient(
-        name = "KakaoInfoClient",
+        name = "KakaoLoginFeignClient",
         url = "https://kapi.kakao.com",
         configuration = KakaoLoginConfig.class)
 @Component
-// Token을 가지고 회원정보를 요청하는 Feign이다.
 public interface KakaoLoginFeignClient {
     @GetMapping("/v2/user/me")
-    KakaoLoginUserDTO getInfo(@RequestHeader(name = "Authorization") String Authorization);
+    KakaoLoginUserDTO getInfo(@RequestHeader(name = "Authorization") String identityToken);
 }

--- a/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/config/KakaoLoginConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/config/KakaoLoginConfig.java
@@ -1,0 +1,23 @@
+package com.nexters.dailyphrase.infra.feign.kakao.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
+
+@Import(KakaoLoginErrorDecoder.class)
+public class KakaoLoginConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(value = ErrorDecoder.class)
+    public KakaoLoginErrorDecoder commonFeignErrorDecoder() {
+        return new KakaoLoginErrorDecoder();
+    }
+
+    @Bean
+    Encoder formEncoder() {
+        return new feign.form.FormEncoder();
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/config/KakaoLoginConfiguration.java
+++ b/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/config/KakaoLoginConfiguration.java
@@ -1,0 +1,26 @@
+package com.nexters.dailyphrase.infra.feign.kakao.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import feign.Logger;
+import feign.RequestInterceptor;
+import feign.codec.ErrorDecoder;
+
+@Import(KakaoLoginErrorDecoder.class)
+public class KakaoLoginConfiguration {
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return template -> template.header("Content-Type", "application/x-www-form-urlencoded");
+    }
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new KakaoLoginErrorDecoder();
+    }
+
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/config/KakaoLoginErrorDecoder.java
+++ b/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/config/KakaoLoginErrorDecoder.java
@@ -1,0 +1,26 @@
+package com.nexters.dailyphrase.infra.feign.kakao.config;
+
+import static com.nexters.dailyphrase.common.exception.GlobalErrorCode.*;
+
+import com.nexters.dailyphrase.common.exception.BaseCodeException;
+
+import feign.FeignException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class KakaoLoginErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        if (response.status() >= 400) {
+            switch (response.status()) {
+                case 401 -> throw new BaseCodeException(OTHER_SERVER_UNAUTHORIZED);
+                case 403 -> throw new BaseCodeException(OTHER_SERVER_FORBIDDEN);
+                case 419 -> throw new BaseCodeException(OTHER_SERVER_EXPIRED_TOKEN);
+                default -> throw new BaseCodeException(OTHER_SERVER_BAD_REQUEST);
+            }
+        }
+
+        return FeignException.errorStatus(methodKey, response);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/config/KakaoLoginErrorDecoder.java
+++ b/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/config/KakaoLoginErrorDecoder.java
@@ -13,6 +13,7 @@ public class KakaoLoginErrorDecoder implements ErrorDecoder {
     @Override
     public Exception decode(String methodKey, Response response) {
         if (response.status() >= 400) {
+            System.out.println(response.toString());
             switch (response.status()) {
                 case 401 -> throw new BaseCodeException(OTHER_SERVER_UNAUTHORIZED);
                 case 403 -> throw new BaseCodeException(OTHER_SERVER_FORBIDDEN);

--- a/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/dto/KakaoLoginUserDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/dto/KakaoLoginUserDTO.java
@@ -1,0 +1,67 @@
+package com.nexters.dailyphrase.infra.feign.kakao.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoLoginUserDTO {
+
+    private Properties properties;
+    private String id;
+
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Properties {
+        private String nickname;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class KakaoAccount {
+
+        private Profile profile;
+        private String email;
+        private String phoneNumber;
+        private String name;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+        public static class Profile {
+            private String profileImageUrl;
+        }
+
+        public String getProfileImageUrl() {
+            return profile.getProfileImageUrl();
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return kakaoAccount.getEmail();
+    }
+
+    public String getPhoneNumber() {
+        return kakaoAccount.getPhoneNumber();
+    }
+
+    public String getName() {
+        return kakaoAccount.getName() != null ? kakaoAccount.getName() : properties.getNickname();
+    }
+
+    public String getProfileUrl() {
+        return kakaoAccount.getProfileImageUrl();
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/dto/KakaoLoginUserDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/infra/feign/kakao/dto/KakaoLoginUserDTO.java
@@ -2,6 +2,9 @@ package com.nexters.dailyphrase.infra.feign.kakao.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.nexters.dailyphrase.common.enums.MemberRole;
+import com.nexters.dailyphrase.common.enums.SocialType;
+import com.nexters.dailyphrase.member.domain.Member;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +18,17 @@ public class KakaoLoginUserDTO {
     private String id;
 
     private KakaoAccount kakaoAccount;
+
+    public Member toMember() {
+        return Member.builder()
+                .name(this.getName())
+                .email(this.getEmail())
+                .socialId(this.getId())
+                .socialType(SocialType.KAKAO)
+                .profileImgUrl(this.getProfileUrl())
+                .role(MemberRole.ROLE_USER)
+                .build();
+    }
 
     @Getter
     @NoArgsConstructor

--- a/src/main/java/com/nexters/dailyphrase/member/business/MemberFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/member/business/MemberFacade.java
@@ -1,5 +1,8 @@
 package com.nexters.dailyphrase.member.business;
 
+import com.nexters.dailyphrase.common.enums.SocialType;
+import com.nexters.dailyphrase.member.presentation.dto.MemberRequestDTO;
+import com.nexters.dailyphrase.member.presentation.dto.MemberResponseDTO;
 import org.springframework.stereotype.Component;
 
 import com.nexters.dailyphrase.member.implement.MemberCommandService;
@@ -12,4 +15,8 @@ import lombok.RequiredArgsConstructor;
 public class MemberFacade {
     private final MemberQueryService memberQueryService;
     private final MemberCommandService memberCommandService;
+
+    public MemberResponseDTO.LoginMember login(final SocialType socialType, final MemberRequestDTO.LoginMember request) {
+        return null;
+    }
 }

--- a/src/main/java/com/nexters/dailyphrase/member/business/MemberFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/member/business/MemberFacade.java
@@ -1,12 +1,15 @@
 package com.nexters.dailyphrase.member.business;
 
-import com.nexters.dailyphrase.common.enums.SocialType;
-import com.nexters.dailyphrase.member.presentation.dto.MemberRequestDTO;
-import com.nexters.dailyphrase.member.presentation.dto.MemberResponseDTO;
 import org.springframework.stereotype.Component;
 
+import com.nexters.dailyphrase.common.enums.SocialType;
+import com.nexters.dailyphrase.member.domain.Member;
 import com.nexters.dailyphrase.member.implement.MemberCommandService;
 import com.nexters.dailyphrase.member.implement.MemberQueryService;
+import com.nexters.dailyphrase.member.implement.SocialLoginService;
+import com.nexters.dailyphrase.member.implement.factory.SocialLoginServiceFactory;
+import com.nexters.dailyphrase.member.presentation.dto.MemberRequestDTO;
+import com.nexters.dailyphrase.member.presentation.dto.MemberResponseDTO;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,8 +18,16 @@ import lombok.RequiredArgsConstructor;
 public class MemberFacade {
     private final MemberQueryService memberQueryService;
     private final MemberCommandService memberCommandService;
+    private final SocialLoginServiceFactory socialLoginServiceFactory;
+    private final MemberMapper memberMapper;
 
-    public MemberResponseDTO.LoginMember login(final SocialType socialType, final MemberRequestDTO.LoginMember request) {
-        return null;
+    public MemberResponseDTO.LoginMember login(
+            final SocialType socialType, final MemberRequestDTO.LoginMember request) {
+        SocialLoginService socialLoginService =
+                socialLoginServiceFactory.getServiceBySocialType(socialType);
+        Member member = socialLoginService.login(request.getIdentityToken());
+        String accessToken = ""; // TODO : redis service에서 RefreshToken 발급
+        String refreshToken = ""; // TODO : token service에서 AccessToken 발급
+        return memberMapper.toLoginMember(member, accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/member/business/MemberFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/member/business/MemberFacade.java
@@ -3,6 +3,7 @@ package com.nexters.dailyphrase.member.business;
 import org.springframework.stereotype.Component;
 
 import com.nexters.dailyphrase.common.enums.SocialType;
+import com.nexters.dailyphrase.common.jwt.JwtTokenService;
 import com.nexters.dailyphrase.member.domain.Member;
 import com.nexters.dailyphrase.member.implement.MemberCommandService;
 import com.nexters.dailyphrase.member.implement.MemberQueryService;
@@ -19,6 +20,7 @@ public class MemberFacade {
     private final MemberQueryService memberQueryService;
     private final MemberCommandService memberCommandService;
     private final SocialLoginServiceFactory socialLoginServiceFactory;
+    private final JwtTokenService jwtTokenService;
     private final MemberMapper memberMapper;
 
     public MemberResponseDTO.LoginMember login(
@@ -26,8 +28,10 @@ public class MemberFacade {
         SocialLoginService socialLoginService =
                 socialLoginServiceFactory.getServiceBySocialType(socialType);
         Member member = socialLoginService.login(request.getIdentityToken());
-        String accessToken = ""; // TODO : redis service에서 RefreshToken 발급
-        String refreshToken = ""; // TODO : token service에서 AccessToken 발급
+        String accessToken =
+                jwtTokenService.generateAccessToken(member.getId(), member.getRole().name());
+        // TODO - Refresh 토큰을 Jwt로 발급하지 않고, Redis를 사용하는 방식도 고려하기
+        String refreshToken = jwtTokenService.generateRefreshToken(member.getId());
         return memberMapper.toLoginMember(member, accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/member/business/MemberMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/member/business/MemberMapper.java
@@ -1,0 +1,18 @@
+package com.nexters.dailyphrase.member.business;
+
+import org.springframework.stereotype.Component;
+
+import com.nexters.dailyphrase.member.domain.Member;
+import com.nexters.dailyphrase.member.presentation.dto.MemberResponseDTO;
+
+@Component
+public class MemberMapper {
+    public MemberResponseDTO.LoginMember toLoginMember(
+            Member member, String accessToken, String refreshToken) {
+        return MemberResponseDTO.LoginMember.builder()
+                .memberId(member.getId())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/member/domain/repository/MemberRepository.java
@@ -1,7 +1,12 @@
 package com.nexters.dailyphrase.member.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.nexters.dailyphrase.common.enums.SocialType;
 import com.nexters.dailyphrase.member.domain.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {}
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findBySocialIdAndSocialType(String socialId, SocialType socialType);
+}

--- a/src/main/java/com/nexters/dailyphrase/member/implement/SocialLoginService.java
+++ b/src/main/java/com/nexters/dailyphrase/member/implement/SocialLoginService.java
@@ -1,0 +1,15 @@
+package com.nexters.dailyphrase.member.implement;
+
+import com.nexters.dailyphrase.member.domain.Member;
+import com.nexters.dailyphrase.member.implement.strategy.SocialLoginStrategy;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SocialLoginService {
+    private final SocialLoginStrategy socialLoginStrategy;
+
+    public Member login(String identityToken) {
+        return this.socialLoginStrategy.login(identityToken);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/member/implement/factory/SocialLoginServiceFactory.java
+++ b/src/main/java/com/nexters/dailyphrase/member/implement/factory/SocialLoginServiceFactory.java
@@ -1,0 +1,30 @@
+package com.nexters.dailyphrase.member.implement.factory;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.nexters.dailyphrase.common.enums.SocialType;
+import com.nexters.dailyphrase.member.implement.SocialLoginService;
+import com.nexters.dailyphrase.member.implement.strategy.SocialLoginStrategy;
+
+@Component
+public class SocialLoginServiceFactory {
+    private final Map<SocialType, SocialLoginService> contextMap;
+
+    @Autowired
+    public SocialLoginServiceFactory(List<SocialLoginStrategy> strategies) {
+        contextMap = new EnumMap<>(SocialType.class);
+        for (SocialLoginStrategy strategy : strategies) {
+            SocialType socialType = strategy.getSocialType();
+            contextMap.put(socialType, new SocialLoginService(strategy));
+        }
+    }
+
+    public SocialLoginService getServiceBySocialType(SocialType socialType) {
+        return contextMap.get(socialType);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/member/implement/strategy/KakaoLoginStrategy.java
+++ b/src/main/java/com/nexters/dailyphrase/member/implement/strategy/KakaoLoginStrategy.java
@@ -1,0 +1,25 @@
+package com.nexters.dailyphrase.member.implement.strategy;
+
+import org.springframework.stereotype.Component;
+
+import com.nexters.dailyphrase.common.enums.SocialType;
+import com.nexters.dailyphrase.member.domain.Member;
+import com.nexters.dailyphrase.member.domain.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoLoginStrategy implements SocialLoginStrategy {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Member login(String identityToken) {
+        return null;
+    }
+
+    @Override
+    public SocialType getSocialType() {
+        return SocialType.KAKAO;
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/member/implement/strategy/SocialLoginStrategy.java
+++ b/src/main/java/com/nexters/dailyphrase/member/implement/strategy/SocialLoginStrategy.java
@@ -1,0 +1,10 @@
+package com.nexters.dailyphrase.member.implement.strategy;
+
+import com.nexters.dailyphrase.common.enums.SocialType;
+import com.nexters.dailyphrase.member.domain.Member;
+
+public interface SocialLoginStrategy {
+    Member login(String identityToken);
+
+    SocialType getSocialType();
+}

--- a/src/main/java/com/nexters/dailyphrase/member/presentation/MemberApi.java
+++ b/src/main/java/com/nexters/dailyphrase/member/presentation/MemberApi.java
@@ -20,7 +20,7 @@ public class MemberApi {
     public CommonResponse<MemberResponseDTO.LoginMember> login(
             @PathVariable final SocialType socialType,
             @RequestBody final MemberRequestDTO.LoginMember request) {
-        return null;
+        return CommonResponse.onSuccess(memberFacade.login(socialType, request));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/nexters/dailyphrase/member/presentation/dto/MemberRequestDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/member/presentation/dto/MemberRequestDTO.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 public class MemberRequestDTO {
     @Getter
     public static class LoginMember {
-        private String field;
+        private String identityToken;
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/member/presentation/dto/MemberResponseDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/member/presentation/dto/MemberResponseDTO.java
@@ -10,7 +10,9 @@ public class MemberResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class LoginMember {
-        private String field;
+        private Long memberId;
+        private String accessToken;
+        private String refreshToken;
     }
 
     @Builder

--- a/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseFacade.java
@@ -18,7 +18,7 @@ public class PhraseFacade {
     private final PhraseMapper phraseMapper;
 
     @Transactional
-    public PhraseResponseDTO.PhraseDetail getPhraseDetail(Long id) {
+    public PhraseResponseDTO.PhraseDetail getPhraseDetail(final Long id) {
         phraseCommandService.increaseViewCountById(id);
         Phrase phrase = phraseQueryService.findById(id);
         return phraseMapper.toPhraseDetail(phrase);

--- a/src/main/java/com/nexters/dailyphrase/phrase/implement/PhraseCommandService.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/implement/PhraseCommandService.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 public class PhraseCommandService {
     private final PhraseRepository phraseRepository;
 
-    public void increaseViewCountById(Long phraseId) {
+    public void increaseViewCountById(final Long phraseId) {
         phraseRepository.updateViewCountById(phraseId);
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/phrase/implement/PhraseQueryService.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/implement/PhraseQueryService.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 public class PhraseQueryService {
     private final PhraseRepository phraseRepository;
 
-    public Phrase findById(Long id) {
+    public Phrase findById(final Long id) {
         return phraseRepository.findById(id).orElseThrow(() -> PhraseNotFoundException.EXCEPTION);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ auth:
   jwt:
     secret-key: ${JWT_SECRET_KEY:testkeytestkeytestkeytestkeytestkeytestkeytestkeytestkeytestkey}
     access-exp: ${JWT_ACCESS_EXP:3600}
-    refresh-exp: ${JWT_REFRESH_EXP:3600}
+    refresh-exp: ${JWT_REFRESH_EXP:2592000}
 
 ---
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,12 @@
 spring:
   profiles:
     active: local
+auth:
+  jwt:
+    secret-key: ${JWT_SECRET_KEY:testkeytestkeytestkeytestkeytestkeytestkeytestkeytestkeytestkey}
+    access-exp: ${JWT_ACCESS_EXP:3600}
+    refresh-exp: ${JWT_REFRESH_EXP:3600}
+
 ---
 spring:
   config:

--- a/src/test/java/com/nexters/dailyphrase/member/presentation/MemberApiIntegretionTest.java
+++ b/src/test/java/com/nexters/dailyphrase/member/presentation/MemberApiIntegretionTest.java
@@ -1,0 +1,41 @@
+package com.nexters.dailyphrase.member.presentation;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MemberApiIntegrationTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired private MemberApi memberApi;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(memberApi).build();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 로그인요청을 했을 때, 400응답이 옵니다.")
+    void 유효하지않은_토큰_요청() throws Exception {
+        String jsonRequest = "{\"identityToken\":\"invalidTokenString\"}";
+
+        mockMvc.perform(
+                        MockMvcRequestBuilders.post("/api/v1/members/login/kakao")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(jsonRequest))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## 🚀 개요
카카오 로그인 API를 구현했습니다.

## 🔍 작업 내용
- 카카오 로그인 API
- JWT 토큰 발급
- 실패 케이스 테스트 코드 작성 (Presentation 계층)
- 구글, 애플 로그인 등 이후 확장을 고려해 전략 패턴을 사용했습니다.
<img width="60%" src="https://github.com/Nexters/daily-phrase-server/assets/53550707/3162481b-272c-469e-afba-5a9df11ee8a0" />

## 📝 논의사항
- 카카오 액세스 토큰 만료시간 때문에 해피케이스 테스트코드를 작성하기가 어려워서 유효하지 않은 요청일 경우만 테스트를 작성했습니다.
    - 성공 스크린샷)
    <img width="415" alt="스크린샷 2024-01-22 오후 5 10 13" src="https://github.com/Nexters/daily-phrase-server/assets/53550707/cd44083b-bc50-4e9c-bed3-49793da462f0">
    <img width="400" alt="스크린샷 2024-01-22 오후 5 51 07" src="https://github.com/Nexters/daily-phrase-server/assets/53550707/1eb9fbf4-9afa-402f-8eba-855c251d9241">


- 현재는 인프라 세팅 이전이라서 RefreshToken을 JWT로 발급하게 작성했는데, RTR 등의 로직을 구성하기 위해 추후 Redis를 사용해야할 것 같습니다.

