### PR TITLE
Feature/53 : 글귀 상세조회 응답 필드 추가

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/common/consts/DailyPhraseStatic.java
+++ b/src/main/java/com/nexters/dailyphrase/common/consts/DailyPhraseStatic.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 public class DailyPhraseStatic {
     public static final String AUTH_HEADER = "Authorization";
     public static final String BEARER = "Bearer ";
+    public static final String NULL_STRING = "null";
     public static final String WITHDRAW_PREFIX = "DELETED:";
     public static final String TOKEN_ROLE = "role";
     public static final String TOKEN_TYPE = "type";

--- a/src/main/java/com/nexters/dailyphrase/common/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/nexters/dailyphrase/common/jwt/JwtAuthorizationFilter.java
@@ -26,8 +26,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             throws ServletException, IOException, java.io.IOException {
 
         String jwt = resolveToken(request);
-
-        if (StringUtils.hasText(jwt) && jwtTokenService.isAccessToken(jwt)) {
+        if (StringUtils.hasText(jwt)
+                && !jwt.equals(NULL_STRING)
+                && jwtTokenService.isAccessToken(jwt)) {
             Authentication authentication = jwtTokenService.getAuthentication(jwt);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseMapper.java
@@ -18,6 +18,7 @@ public class PhraseMapper {
                         .orElse(""); // 또는 기본값 사용
 
         return PhraseResponseDTO.PhraseDetail.builder()
+                .phraseId(phrase.getId())
                 .title(phrase.getTitle())
                 .imageUrl(imageUrl)
                 .content(phrase.getContent())

--- a/src/main/java/com/nexters/dailyphrase/phrase/presentation/dto/PhraseResponseDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/presentation/dto/PhraseResponseDTO.java
@@ -13,6 +13,7 @@ public class PhraseResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class PhraseDetail {
+        private Long phraseId;
         private String title;
         private String imageUrl;
         private String content;


### PR DESCRIPTION
## 🚀 개요
글귀 상세 조회 API에 응답 필드를 추가하고, Jwt 필터 로직을 수정했습니다.

## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
- 글귀 상세 조회 API phraseId 추가
- Jwt 필터 로직 수정

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

