### PR TITLE
Feature/38 : 사용자 인가처리 & 글귀 상세/목록 조회 응답 필드 추가

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/common/utils/MemberUtils.java
+++ b/src/main/java/com/nexters/dailyphrase/common/utils/MemberUtils.java
@@ -1,0 +1,24 @@
+package com.nexters.dailyphrase.common.utils;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.nexters.dailyphrase.member.domain.Member;
+import com.nexters.dailyphrase.member.domain.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberUtils {
+    private final MemberRepository memberRepository;
+
+    public Long getCurrentMemberId() {
+        return SecurityUtils.getCurrentMemberId();
+    }
+
+    public Optional<Member> getCurrentMember() {
+        return memberRepository.findById(getCurrentMemberId());
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/common/utils/SecurityUtils.java
+++ b/src/main/java/com/nexters/dailyphrase/common/utils/SecurityUtils.java
@@ -11,7 +11,7 @@ public class SecurityUtils {
 
     public static Long getCurrentMemberId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null) return 0L;
+        if (authentication == null || authentication.getName().equals("anonymousUser")) return 0L;
         return Long.valueOf(authentication.getName());
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/common/utils/SecurityUtils.java
+++ b/src/main/java/com/nexters/dailyphrase/common/utils/SecurityUtils.java
@@ -1,0 +1,17 @@
+package com.nexters.dailyphrase.common.utils;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SecurityUtils {
+
+    public static Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) return 0L;
+        return Long.valueOf(authentication.getName());
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
@@ -20,12 +20,18 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
     private final JwtTokenService jwtTokenService;
     //    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     //    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     private final String[] allowedUrls = {
-        "/", "/swagger-ui/**", "/api/v1/**", "/api/admin/login", "/api-docs/**"
+        "/",
+        "/swagger-ui/**",
+        "/api/v1/phrases/**",
+        "/api/v1/members/login/{socialType}",
+        "/api/admin/login",
+        "/api-docs/**"
     };
 
     //    @Component
@@ -73,6 +79,11 @@ public class SecurityConfig {
                                         .permitAll()
                                         .requestMatchers("/api/admin/**")
                                         .hasAuthority("ROLE_ADMIN")
+                                        .requestMatchers(
+                                                "/api/v1/members/**",
+                                                "/api/v1/likes/**",
+                                                "/api/v1/favorites/**")
+                                        .authenticated()
                                         .anyRequest()
                                         .authenticated())
                 .addFilterBefore(

--- a/src/main/java/com/nexters/dailyphrase/favorite/domain/repository/FavoriteRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/favorite/domain/repository/FavoriteRepository.java
@@ -13,5 +13,5 @@ public interface FavoriteRepository
 
     List<Favorite> findByMember_Id(Long id);
 
-    boolean existsByMember_Id(Long memberId);
+    boolean existsByMember_IdAndPhrase_Id(Long memberId, Long phraseId);
 }

--- a/src/main/java/com/nexters/dailyphrase/favorite/domain/repository/FavoriteRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/favorite/domain/repository/FavoriteRepository.java
@@ -12,4 +12,6 @@ public interface FavoriteRepository
     Optional<Favorite> findByMember_IdAndPhrase_Id(Long memberId, Long phraseId);
 
     List<Favorite> findByMember_Id(Long id);
+
+    boolean existsByMember_Id(Long memberId);
 }

--- a/src/main/java/com/nexters/dailyphrase/favorite/implement/FavoriteQueryService.java
+++ b/src/main/java/com/nexters/dailyphrase/favorite/implement/FavoriteQueryService.java
@@ -29,4 +29,8 @@ public class FavoriteQueryService {
     public List<Favorite> findByMemberId(Long id) {
         return favoriteRepository.findByMember_Id(id);
     }
+
+    public boolean existsByMemberId(Long memberId) {
+        return favoriteRepository.existsByMember_Id(memberId);
+    }
 }

--- a/src/main/java/com/nexters/dailyphrase/favorite/implement/FavoriteQueryService.java
+++ b/src/main/java/com/nexters/dailyphrase/favorite/implement/FavoriteQueryService.java
@@ -30,7 +30,7 @@ public class FavoriteQueryService {
         return favoriteRepository.findByMember_Id(id);
     }
 
-    public boolean existsByMemberId(Long memberId) {
-        return favoriteRepository.existsByMember_Id(memberId);
+    public boolean existsByMemberIdAndPhraseId(Long memberId, Long phraseId) {
+        return favoriteRepository.existsByMember_IdAndPhrase_Id(memberId, phraseId);
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/like/domain/repository/LikeRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/like/domain/repository/LikeRepository.java
@@ -14,5 +14,5 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     int countByPhrase_Id(Long id);
 
-    boolean existsByMember_Id(Long memberId);
+    boolean existsByMember_IdAndPhrase_Id(Long memberId, Long phraseId);
 }

--- a/src/main/java/com/nexters/dailyphrase/like/domain/repository/LikeRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/like/domain/repository/LikeRepository.java
@@ -13,4 +13,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     List<Like> findByMember_Id(Long memberId);
 
     int countByPhrase_Id(Long id);
+
+    boolean existsByMember_Id(Long memberId);
 }

--- a/src/main/java/com/nexters/dailyphrase/like/implement/LikeQueryService.java
+++ b/src/main/java/com/nexters/dailyphrase/like/implement/LikeQueryService.java
@@ -29,7 +29,7 @@ public class LikeQueryService {
         return likeRepository.countByPhrase_Id(id);
     }
 
-    public boolean existsByMemberId(Long memberId) {
-        return likeRepository.existsByMember_Id(memberId);
+    public boolean existsByMemberIdAndPhraseId(Long memberId, Long phraseId) {
+        return likeRepository.existsByMember_IdAndPhrase_Id(memberId, phraseId);
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/like/implement/LikeQueryService.java
+++ b/src/main/java/com/nexters/dailyphrase/like/implement/LikeQueryService.java
@@ -28,4 +28,8 @@ public class LikeQueryService {
     public int countByPhraseId(Long id) {
         return likeRepository.countByPhrase_Id(id);
     }
+
+    public boolean existsByMemberId(Long memberId) {
+        return likeRepository.existsByMember_Id(memberId);
+    }
 }

--- a/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseFacade.java
@@ -29,8 +29,8 @@ public class PhraseFacade {
         Phrase phrase = phraseQueryService.findById(id);
         int likeCount = likeQueryService.countByPhraseId(id);
         Long memberId = memberUtils.getCurrentMemberId();
-        boolean isLike = likeQueryService.existsByMemberId(memberId);
-        boolean isFavorite = favoriteQueryService.existsByMemberId(memberId);
+        boolean isLike = likeQueryService.existsByMemberIdAndPhraseId(memberId, id);
+        boolean isFavorite = favoriteQueryService.existsByMemberIdAndPhraseId(memberId, id);
         return phraseMapper.toPhraseDetail(phrase, likeCount, isLike, isFavorite);
     }
 

--- a/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseFacade.java
@@ -3,6 +3,8 @@ package com.nexters.dailyphrase.phrase.business;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.nexters.dailyphrase.common.utils.MemberUtils;
+import com.nexters.dailyphrase.favorite.implement.FavoriteQueryService;
 import com.nexters.dailyphrase.like.implement.LikeQueryService;
 import com.nexters.dailyphrase.phrase.domain.Phrase;
 import com.nexters.dailyphrase.phrase.implement.PhraseCommandService;
@@ -17,14 +19,19 @@ public class PhraseFacade {
     private final PhraseQueryService phraseQueryService;
     private final PhraseCommandService phraseCommandService;
     private final LikeQueryService likeQueryService;
+    private final FavoriteQueryService favoriteQueryService;
     private final PhraseMapper phraseMapper;
+    private final MemberUtils memberUtils;
 
     @Transactional
     public PhraseResponseDTO.PhraseDetail getPhraseDetail(final Long id) {
         phraseCommandService.increaseViewCountById(id);
         Phrase phrase = phraseQueryService.findById(id);
         int likeCount = likeQueryService.countByPhraseId(id);
-        return phraseMapper.toPhraseDetail(phrase, likeCount);
+        Long memberId = memberUtils.getCurrentMemberId();
+        boolean isLike = likeQueryService.existsByMemberId(memberId);
+        boolean isFavorite = favoriteQueryService.existsByMemberId(memberId);
+        return phraseMapper.toPhraseDetail(phrase, likeCount, isLike, isFavorite);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseMapper.java
@@ -11,7 +11,8 @@ import com.nexters.dailyphrase.phraseimage.domain.PhraseImage;
 @Component
 public class PhraseMapper {
 
-    public PhraseResponseDTO.PhraseDetail toPhraseDetail(Phrase phrase, int likeCount) {
+    public PhraseResponseDTO.PhraseDetail toPhraseDetail(
+            Phrase phrase, int likeCount, boolean isLike, boolean isFavorite) {
         String imageUrl =
                 Optional.ofNullable(phrase.getPhraseImage())
                         .map(PhraseImage::getUrl)
@@ -24,6 +25,8 @@ public class PhraseMapper {
                 .content(phrase.getContent())
                 .viewCount(phrase.getViewCount())
                 .likeCount(likeCount)
+                .isLike(isLike)
+                .isFavorite(isFavorite)
                 .build();
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseMapper.java
@@ -22,6 +22,7 @@ public class PhraseMapper {
                 .phraseId(phrase.getId())
                 .title(phrase.getTitle())
                 .imageUrl(imageUrl)
+                .imageRatio(phrase.getPhraseImage().getImageRatio())
                 .content(phrase.getContent())
                 .viewCount(phrase.getViewCount())
                 .likeCount(likeCount)

--- a/src/main/java/com/nexters/dailyphrase/phrase/domain/repository/PhraseCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/domain/repository/PhraseCustomRepositoryImpl.java
@@ -5,11 +5,14 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import com.nexters.dailyphrase.admin.presentation.dto.AdminResponseDTO;
+import com.nexters.dailyphrase.common.utils.MemberUtils;
+import com.nexters.dailyphrase.favorite.domain.QFavorite;
 import com.nexters.dailyphrase.like.domain.QLike;
 import com.nexters.dailyphrase.phrase.domain.QPhrase;
 import com.nexters.dailyphrase.phrase.presentation.dto.PhraseResponseDTO;
 import com.nexters.dailyphrase.phraseimage.domain.QPhraseImage;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -18,17 +21,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PhraseCustomRepositoryImpl implements PhraseCustomRepository {
     private final JPAQueryFactory queryFactory;
+    private final MemberUtils memberUtils;
 
     @Override
     public PhraseResponseDTO.PhraseList findPhraseListDTO(int page, int size) {
         QPhrase qPhrase = QPhrase.phrase;
         QPhraseImage qPhraseImage = QPhraseImage.phraseImage;
         QLike qLike = QLike.like;
+        QFavorite qFavorite = QFavorite.favorite;
 
         int offset = (page - 1) * size;
         long totalElemCount = queryFactory.select(qPhrase.count()).from(qPhrase).fetchOne();
         long totalPageCount = (totalElemCount + size - 1) / size;
         boolean hasNext = page < totalPageCount;
+
+        Long memberId = memberUtils.getCurrentMemberId();
 
         // Use Projections.constructor to directly map the results to PhraseListItem
         List<PhraseResponseDTO.PhraseListItem> phraseListItems =
@@ -42,7 +49,24 @@ public class PhraseCustomRepositoryImpl implements PhraseCustomRepository {
                                         qPhraseImage.url.coalesce(""),
                                         qPhraseImage.imageRatio.coalesce(""),
                                         qPhrase.viewCount,
-                                        qLike.count().intValue()))
+                                        qLike.count().intValue(),
+                                        JPAExpressions.selectOne()
+                                                .from(qLike)
+                                                .where(
+                                                        qLike.phrase
+                                                                .eq(qPhrase)
+                                                                .and(qLike.member.id.eq(memberId)))
+                                                .exists(),
+                                        JPAExpressions.selectOne()
+                                                .from(qFavorite)
+                                                .where(
+                                                        qFavorite
+                                                                .phrase
+                                                                .eq(qPhrase)
+                                                                .and(
+                                                                        qFavorite.member.id.eq(
+                                                                                memberId)))
+                                                .exists()))
                         .from(qPhrase)
                         .leftJoin(qPhrase.phraseImage, qPhraseImage)
                         .leftJoin(qLike)

--- a/src/main/java/com/nexters/dailyphrase/phrase/presentation/dto/PhraseResponseDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/presentation/dto/PhraseResponseDTO.java
@@ -16,6 +16,7 @@ public class PhraseResponseDTO {
         private Long phraseId;
         private String title;
         private String imageUrl;
+        private String imageRatio;
         private String content;
         private int viewCount;
         private int likeCount;

--- a/src/main/java/com/nexters/dailyphrase/phrase/presentation/dto/PhraseResponseDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/presentation/dto/PhraseResponseDTO.java
@@ -19,6 +19,8 @@ public class PhraseResponseDTO {
         private String content;
         private int viewCount;
         private int likeCount;
+        @Builder.Default private Boolean isLike = false;
+        @Builder.Default private Boolean isFavorite = false;
     }
 
     @Builder
@@ -33,6 +35,8 @@ public class PhraseResponseDTO {
         private String imageRatio;
         private int viewCount;
         private int likeCount;
+        @Builder.Default private Boolean isLike = false;
+        @Builder.Default private Boolean isFavorite = false;
     }
 
     @Builder


### PR DESCRIPTION
## 🚀 개요
사용자 API들 중 인가처리가 필요한 API 인가처리를 했습니다.
글귀 상세/목록 조회에 isLike, isFavorite 필드를 추가했습니다.

## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
-  사용자 API 인가처리
-  isLike, isFavorite (글귀 상세/목록 조회 API)

## 📝 논의사항
- MemberUtils에서 현재 인증되지 않은 사용자이거나 익명인 사용자의 경우 0L을 반환하도록 구현했습니다.
- 글귀 단 건 조회 시, 조회 수 업데이트 및 여러 필드를 가져오느라 쿼리가 여러번 나가는데 추후에 QueryDSL을 사용해서 쿼리 2번으로 줄여보겠습니다.

