### PR TITLE
fix/69 content 글자수 제한 오류 수정

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
@@ -18,7 +18,7 @@ public class Phrase extends BaseDateTimeEntity {
     private Long id;
 
     private String title;
-    @Column(nullable = false, length = 10000)
+    @Column(length = 10000)
     private String content;
 
     @Builder.Default private int viewCount = 0;

--- a/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/domain/Phrase.java
@@ -18,7 +18,7 @@ public class Phrase extends BaseDateTimeEntity {
     private Long id;
 
     private String title;
-
+    @Column(nullable = false, length = 10000)
     private String content;
 
     @Builder.Default private int viewCount = 0;


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
phrase 의 content 글자수가 255 자로 되어있어 긴 글은 업로드 되지 않아 이를 해결합니다.

## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
- phrase 도메인의 content 수정
- phrase 테이블 varchar(255)->varchar(10000)

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
