### PR TITLE
fix/76: CORS 정책 설정-인증 허용

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/config/GlobalWebConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/GlobalWebConfig.java
@@ -21,10 +21,10 @@ public class GlobalWebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOrigins("http://localhost:3020","https://daily-phrase-web-web-kappa.vercel.app","http://www.daily-phrase.com","http://admin.daily-phrase.com")
                 .allowedMethods("*")
                 .allowedHeaders("*")
-                .allowCredentials(false)
+                .allowCredentials(true)
                 .maxAge(6000);
     }
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
인증이 불필요한 /login을 제외한 모든 관리자 api 에서 CORS에러가 발생하여 이를 수정합니다

## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
-  origin 도메인 특정해서 설정해주기 (credentials true와 origin 와일드카드(*)속성은 공존할 수 없음)
-  인증이 필요한 url을 위해, credentials 속성 true로 바꾸기

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
허용될 도메인 추가/수정이 필요하면 말해주세요~

