### PR TITLE
Feature/80:Security Config 예외처리 추가

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/admin/exception/AdminErrorCode.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/exception/AdminErrorCode.java
@@ -1,7 +1,6 @@
 package com.nexters.dailyphrase.admin.exception;
 
-import static com.nexters.dailyphrase.common.consts.DailyPhraseStatic.NOT_FOUND;
-import static com.nexters.dailyphrase.common.consts.DailyPhraseStatic.UNAUTHORIZED;
+import static com.nexters.dailyphrase.common.consts.DailyPhraseStatic.*;
 
 import java.lang.reflect.Field;
 import java.util.Objects;
@@ -17,7 +16,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AdminErrorCode implements BaseErrorCode {
     ADMIN_NOT_FOUND(NOT_FOUND, "ADMIN_404_1", "해당 관리자를 찾을 수 없습니다."),
-    ADMIN_BAD_CREDENTIALS_EXCEPTION(UNAUTHORIZED, "ADMIN_401_1", "자격증명이 없습니다. 아이디 또는 비밀번호가 틀렸습니다.");
+    ADMIN_BAD_CREDENTIALS_EXCEPTION(UNAUTHORIZED, "ADMIN_401_1", "자격증명이 없습니다. 아이디 또는 비밀번호가 틀렸습니다."),
+    ADMIN_UNAUTHORIZED_EXCEPTION(UNAUTHORIZED, "ADMIN_401_2", "유효하지 않은 자격증명입니다."),
+    ADMIN_FORBIDDEN_EXCEPTION(FORBIDDEN, "ADMIN_403_1", "필요한 권한이 없습니다.");
 
     private final Integer status;
     private final String code;

--- a/src/main/java/com/nexters/dailyphrase/admin/exception/AdminForbiddenException.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/exception/AdminForbiddenException.java
@@ -1,0 +1,12 @@
+package com.nexters.dailyphrase.admin.exception;
+
+import com.nexters.dailyphrase.common.exception.BaseCodeException;
+
+public class AdminForbiddenException extends BaseCodeException {
+
+    public static BaseCodeException EXCEPTION = new AdminForbiddenException();
+
+    public AdminForbiddenException() {
+        super(AdminErrorCode.ADMIN_FORBIDDEN_EXCEPTION);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/admin/exception/AdminUnauthorizedException.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/exception/AdminUnauthorizedException.java
@@ -1,0 +1,12 @@
+package com.nexters.dailyphrase.admin.exception;
+
+import com.nexters.dailyphrase.common.exception.BaseCodeException;
+
+public class AdminUnauthorizedException extends BaseCodeException {
+
+    public static BaseCodeException EXCEPTION = new AdminUnauthorizedException();
+
+    public AdminUnauthorizedException() {
+        super(AdminErrorCode.ADMIN_UNAUTHORIZED_EXCEPTION);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/config/GlobalWebConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/GlobalWebConfig.java
@@ -21,7 +21,12 @@ public class GlobalWebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3020","https://daily-phrase-web-web-kappa.vercel.app","http://www.daily-phrase.com","http://admin.daily-phrase.com")
+                .allowedOrigins(
+                        "http://localhost:3020",
+                        "http://localhost:8080",
+                        "https://daily-phrase-web-web-kappa.vercel.app",
+                        "http://www.daily-phrase.com",
+                        "http://admin.daily-phrase.com")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
@@ -1,16 +1,28 @@
 package com.nexters.dailyphrase.config;
 
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
 
+import com.nexters.dailyphrase.admin.exception.AdminErrorCode;
 import com.nexters.dailyphrase.common.jwt.JwtAuthorizationFilter;
 import com.nexters.dailyphrase.common.jwt.JwtTokenService;
 
@@ -22,8 +34,8 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
     private final JwtTokenService jwtTokenService;
-    //    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-    //    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     private final String[] allowedUrls = {
         "/",
@@ -34,31 +46,54 @@ public class SecurityConfig {
         "/api-docs/**"
     };
 
-    //    @Component
-    //    public static class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Component
+    public static class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    //        @Override
-    //        public void commence(
-    //                HttpServletRequest request,
-    //                HttpServletResponse response,
-    //                AuthenticationException authException)
-    //                throws IOException {
-    //
-    //            response.sendError(HttpServletResponse.SC_FORBIDDEN);
-    //        }
-    //    }
-    //
-    //    @Component
-    //    public static class JwtAccessDeniedHandler implements AccessDeniedHandler {
-    //        @Override
-    //        public void handle(
-    //                HttpServletRequest request,
-    //                HttpServletResponse response,
-    //                AccessDeniedException accessDeniedException)
-    //                throws IOException, ServletException {
-    //            response.sendError(HttpServletResponse.SC_FORBIDDEN);
-    //        }
-    //    }
+        @Override
+        public void commence(
+                HttpServletRequest request,
+                HttpServletResponse response,
+                AuthenticationException authException)
+                throws IOException {
+            response.setCharacterEncoding("UTF-8");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+            AdminErrorCode unauthorizedError = AdminErrorCode.ADMIN_UNAUTHORIZED_EXCEPTION;
+
+            String ErrorResponse =
+                    String.format(
+                            "{\"isSuccess\":\"false\", \"code\":\"%s\", \"message\":\"%s\", \"status\":%d}",
+                            unauthorizedError.getCode(),
+                            unauthorizedError.getReason(),
+                            HttpServletResponse.SC_UNAUTHORIZED);
+
+            response.getWriter().write(ErrorResponse);
+        }
+    }
+
+    @Component
+    public static class JwtAccessDeniedHandler implements AccessDeniedHandler {
+        @Override
+        public void handle(
+                HttpServletRequest request,
+                HttpServletResponse response,
+                AccessDeniedException accessDeniedException)
+                throws IOException, ServletException {
+            response.setCharacterEncoding("UTF-8");
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+            AdminErrorCode forbiddenError = AdminErrorCode.ADMIN_FORBIDDEN_EXCEPTION;
+
+            String ErrorResponse =
+                    String.format(
+                            "{\"isSuccess\":\"false\", \"code\":\"%s\", \"message\":\"%s\", \"status\":%d}",
+                            forbiddenError.getCode(),
+                            forbiddenError.getReason(),
+                            HttpServletResponse.SC_FORBIDDEN);
+
+            response.getWriter().write(ErrorResponse);
+        }
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -66,13 +101,11 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(
                         sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                //                .exceptionHandling(
-                //                        (exception) ->
-                //                                exception
-                //
-                // .authenticationEntryPoint(jwtAuthenticationEntryPoint)
-                //
-                // .accessDeniedHandler(jwtAccessDeniedHandler))
+                .exceptionHandling(
+                        (exception) ->
+                                exception
+                                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                                        .accessDeniedHandler(jwtAccessDeniedHandler))
                 .authorizeHttpRequests(
                         auth ->
                                 auth.requestMatchers(allowedUrls)

--- a/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
@@ -22,6 +22,8 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.nexters.dailyphrase.admin.exception.AdminErrorCode;
 import com.nexters.dailyphrase.common.jwt.JwtAuthorizationFilter;
 import com.nexters.dailyphrase.common.jwt.JwtTokenService;
@@ -60,12 +62,13 @@ public class SecurityConfig {
 
             AdminErrorCode unauthorizedError = AdminErrorCode.ADMIN_UNAUTHORIZED_EXCEPTION;
 
-            String ErrorResponse =
-                    String.format(
-                            "{\"isSuccess\":\"false\", \"code\":\"%s\", \"message\":\"%s\", \"status\":%d}",
-                            unauthorizedError.getCode(),
-                            unauthorizedError.getReason(),
-                            HttpServletResponse.SC_UNAUTHORIZED);
+            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectNode ErrorNode = objectMapper.createObjectNode();
+            ErrorNode.put("isSuccess", "false");
+            ErrorNode.put("code", unauthorizedError.getCode());
+            ErrorNode.put("message", unauthorizedError.getReason());
+            ErrorNode.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+            String ErrorResponse = objectMapper.writeValueAsString(ErrorNode);
 
             response.getWriter().write(ErrorResponse);
         }
@@ -84,12 +87,13 @@ public class SecurityConfig {
 
             AdminErrorCode forbiddenError = AdminErrorCode.ADMIN_FORBIDDEN_EXCEPTION;
 
-            String ErrorResponse =
-                    String.format(
-                            "{\"isSuccess\":\"false\", \"code\":\"%s\", \"message\":\"%s\", \"status\":%d}",
-                            forbiddenError.getCode(),
-                            forbiddenError.getReason(),
-                            HttpServletResponse.SC_FORBIDDEN);
+            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectNode ErrorNode = objectMapper.createObjectNode();
+            ErrorNode.put("isSuccess", "false");
+            ErrorNode.put("code", forbiddenError.getCode());
+            ErrorNode.put("message", forbiddenError.getReason());
+            ErrorNode.put("status", HttpServletResponse.SC_FORBIDDEN);
+            String ErrorResponse = objectMapper.writeValueAsString(ErrorNode);
 
             response.getWriter().write(ErrorResponse);
         }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
Security Config 에 401(유효하지 않은 증명),403(권한없는 접근)과 관련된 예외처리를 추가합니다.


## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
- ADMIN_UNAUTHORIZED_EXCEPTION 추가
-  ADMIN_FORBIDDEN_EXCEPTION 추가

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- SecurityConfig의 예외처리는 status 오류 설정 등을 직접 설정해줘야해서 그런지  throw AdminUnauthorizedException.EXCEPTION 을 했을때 로그에 null 이 나오면서 500에러가 떨어졌습니다.
-  그래서 예외처리 클래스를 그대로 사용하지 않고 response,code 등을 json으로 반환할 수 있도록 직접 만들어주었습니다. 

