### PR TITLE
fix/84: CORS 정책 수정-preflight 허용

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/admin/presentation/AdminApi.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/presentation/AdminApi.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/admin")
 public class AdminApi {
     private final AdminFacade adminFacade;
-
+    @CrossOrigin(allowCredentials = "false", allowedHeaders = "*", origins = "*", maxAge = 6000, methods = RequestMethod.POST)
     @Operation(summary = "05-07 Admin👷🏻 관리자 로그인 Made By 채은", description = "관리자 로그인 API입니다.")
     @PostMapping("/login")
     public CommonResponse<AdminResponseDTO.LoginAdmin> loginAdmin(
@@ -28,7 +28,7 @@ public class AdminApi {
     }
 
     @Operation(
-            summary = "05-07 Admin👷🏻 관리자 로그인 토큰 재발행 Made By 채은",
+            summary = "05-08 Admin👷🏻 관리자 로그인 토큰 재발행 Made By 채은",
             description = "관리자 로그인 토큰 재발행 API입니다.")
     @PostMapping("/reissue")
     public void reissueToken() {}

--- a/src/main/java/com/nexters/dailyphrase/config/GlobalWebConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/GlobalWebConfig.java
@@ -32,4 +32,13 @@ public class GlobalWebConfig implements WebMvcConfigurer {
                 .allowCredentials(true)
                 .maxAge(6000);
     }
+
+    public void addPhraseCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/phrase/**")
+                .allowedOrigins("*")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(6000);
+    }
 }

--- a/src/main/java/com/nexters/dailyphrase/config/GlobalWebConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/GlobalWebConfig.java
@@ -38,7 +38,7 @@ public class GlobalWebConfig implements WebMvcConfigurer {
                 .allowedOrigins("*")
                 .allowedMethods("*")
                 .allowedHeaders("*")
-                .allowCredentials(true)
+                .allowCredentials(false)
                 .maxAge(6000);
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -121,6 +122,8 @@ public class SecurityConfig {
                                                 "/api/v1/likes/**",
                                                 "/api/v1/favorites/**")
                                         .authenticated()
+                                        .requestMatchers(HttpMethod.OPTIONS, "/**")
+                                        .permitAll()
                                         .anyRequest()
                                         .authenticated())
                 .addFilterBefore(

--- a/src/main/java/com/nexters/dailyphrase/member/presentation/MemberApi.java
+++ b/src/main/java/com/nexters/dailyphrase/member/presentation/MemberApi.java
@@ -39,6 +39,7 @@ public class MemberApi {
             summary = "01-03 Member\uD83D\uDC64 소셜 로그인 Made By 성훈",
             description = "KAKAO 소셜로그인 API입니다.")
     @ApiErrorCodeExample(value = {FeignErrorCode.class, GlobalErrorCode.class})
+    @CrossOrigin(allowCredentials = "false", allowedHeaders = "*", origins = "*", maxAge = 6000, methods = RequestMethod.POST)
     @PostMapping("/login/{socialType}")
     public CommonResponse<MemberResponseDTO.LoginMember> login(
             @PathVariable final SocialType socialType,

--- a/src/main/java/com/nexters/dailyphrase/phrase/presentation/PhraseApi.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/presentation/PhraseApi.java
@@ -25,7 +25,6 @@ public class PhraseApi {
     private final PhraseFacade phraseFacade;
 
     @Operation(summary = "02-01 Phrase📄 글귀 목록 조회 Made By 성훈", description = "글귀 목록 조회 API입니다.")
-    @CrossOrigin(allowCredentials = "false", allowedHeaders = "*", origins = "*", maxAge = 6000, methods = RequestMethod.GET)
     @ApiErrorCodeExample(value = {GlobalErrorCode.class})
     @GetMapping
     public CommonResponse<PhraseResponseDTO.PhraseList> getPhraseList(
@@ -39,7 +38,6 @@ public class PhraseApi {
     }
 
     @Operation(summary = "02-02 Phrase📄 글귀 상세 조회 Made By 성훈", description = "글귀 상세 조회 API입니다.")
-    @CrossOrigin(allowCredentials = "false", allowedHeaders = "*", origins = "*", maxAge = 6000, methods = RequestMethod.GET)
     @ApiErrorCodeExample(value = {PhraseErrorCode.class, GlobalErrorCode.class})
     @GetMapping("/{id}")
     public CommonResponse<PhraseResponseDTO.PhraseDetail> getPhraseDetail(

--- a/src/main/java/com/nexters/dailyphrase/phrase/presentation/PhraseApi.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/presentation/PhraseApi.java
@@ -25,6 +25,7 @@ public class PhraseApi {
     private final PhraseFacade phraseFacade;
 
     @Operation(summary = "02-01 Phrase📄 글귀 목록 조회 Made By 성훈", description = "글귀 목록 조회 API입니다.")
+    @CrossOrigin(allowCredentials = "false", allowedHeaders = "*", origins = "*", maxAge = 6000, methods = RequestMethod.GET)
     @ApiErrorCodeExample(value = {GlobalErrorCode.class})
     @GetMapping
     public CommonResponse<PhraseResponseDTO.PhraseList> getPhraseList(
@@ -38,6 +39,7 @@ public class PhraseApi {
     }
 
     @Operation(summary = "02-02 Phrase📄 글귀 상세 조회 Made By 성훈", description = "글귀 상세 조회 API입니다.")
+    @CrossOrigin(allowCredentials = "false", allowedHeaders = "*", origins = "*", maxAge = 6000, methods = RequestMethod.GET)
     @ApiErrorCodeExample(value = {PhraseErrorCode.class, GlobalErrorCode.class})
     @GetMapping("/{id}")
     public CommonResponse<PhraseResponseDTO.PhraseDetail> getPhraseDetail(


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
- 아래와 같이 발생하는 CORS 오류를 해결하기 위해 정책을 수정합니다.
![image](https://github.com/Nexters/daily-phrase-server/assets/10321338/47222ea9-e9a1-4b67-aa49-c1af283be272)


## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
- CORS에서 preflight 요청시 사용하는 메서드 'OPTION'을 SecurityConfig 에서 허용해줍니다.
- credential 설정이 false여야 하는 allowedUrls(login, phrase api)의 경우 개별적인 CORS 정책을 설정해줍니다.(@CrossOrigin 사용)

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
[참고자료] https://ahndding.tistory.com/17