### PR TITLE
fix/88: 관리자 글 삭제 API 수정

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/admin/business/AdminFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/business/AdminFacade.java
@@ -175,8 +175,6 @@ public class AdminFacade {
     @Transactional
     public AdminResponseDTO.DeletePhrase deletePhrase(final Long id) {
 
-        phraseQueryService.findById(id); // PhraseId Notfound 예외처리용
-
         favoriteCommandService.deleteByPhraseId(id);
         likeCommandService.deleteByPhraseId(id);
         phraseImageCommandService.deleteByPhraseId(id);

--- a/src/main/java/com/nexters/dailyphrase/admin/business/AdminFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/business/AdminFacade.java
@@ -22,6 +22,8 @@ import com.nexters.dailyphrase.admin.implement.AdminQueryService;
 import com.nexters.dailyphrase.admin.presentation.dto.AdminRequestDTO;
 import com.nexters.dailyphrase.admin.presentation.dto.AdminResponseDTO;
 import com.nexters.dailyphrase.common.jwt.JwtTokenService;
+import com.nexters.dailyphrase.favorite.implement.FavoriteCommandService;
+import com.nexters.dailyphrase.like.implement.LikeCommandService;
 import com.nexters.dailyphrase.phrase.domain.Phrase;
 import com.nexters.dailyphrase.phrase.implement.PhraseCommandService;
 import com.nexters.dailyphrase.phrase.implement.PhraseQueryService;
@@ -35,6 +37,8 @@ import lombok.RequiredArgsConstructor;
 public class AdminFacade {
     private final PhraseCommandService phraseCommandService;
     private final PhraseQueryService phraseQueryService;
+    private final FavoriteCommandService favoriteCommandService;
+    private final LikeCommandService likeCommandService;
     private final AdminQueryService adminQueryService;
     private final PhraseImageCommandService phraseImageCommandService;
     private final AdminMapper adminMapper;
@@ -171,9 +175,13 @@ public class AdminFacade {
     @Transactional
     public AdminResponseDTO.DeletePhrase deletePhrase(final Long id) {
 
+        phraseQueryService.findById(id); // PhraseId Notfound 예외처리용
+
+        favoriteCommandService.deleteByPhraseId(id);
+        likeCommandService.deleteByPhraseId(id);
         phraseImageCommandService.deleteByPhraseId(id);
         phraseCommandService.deleteById(id);
 
-        return adminMapper.toDeletePhrase();
+        return adminMapper.toDeletePhrase(id);
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/admin/business/AdminMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/business/AdminMapper.java
@@ -108,8 +108,11 @@ public class AdminMapper {
                 .build();
     }
 
-    public AdminResponseDTO.DeletePhrase toDeletePhrase() {
-        return AdminResponseDTO.DeletePhrase.builder().deletedAt(LocalDateTime.now()).build();
+    public AdminResponseDTO.DeletePhrase toDeletePhrase(Long id) {
+        return AdminResponseDTO.DeletePhrase.builder()
+                .phraseId(id)
+                .deletedAt(LocalDateTime.now())
+                .build();
     }
 
     public AdminResponseDTO.LoginAdmin toLogin(

--- a/src/main/java/com/nexters/dailyphrase/admin/presentation/AdminApi.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/presentation/AdminApi.java
@@ -88,7 +88,6 @@ public class AdminApi {
 
     @Operation(summary = "05-01 Admin️👷🏻 관리자 글귀 삭제 Made By 채은", description = "관리자 글귀 삭제 API입니다.")
     @DeleteMapping("/phrases/{id}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     public CommonResponse<AdminResponseDTO.DeletePhrase> deletePhrase(@PathVariable final Long id) {
         return CommonResponse.onSuccess(adminFacade.deletePhrase(id));
     }

--- a/src/main/java/com/nexters/dailyphrase/admin/presentation/dto/AdminResponseDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/presentation/dto/AdminResponseDTO.java
@@ -111,6 +111,7 @@ public class AdminResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DeletePhrase {
+        private Long phraseId;
         private LocalDateTime deletedAt;
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/favorite/domain/repository/FavoriteRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/favorite/domain/repository/FavoriteRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.nexters.dailyphrase.favorite.domain.Favorite;
 
@@ -12,6 +14,10 @@ public interface FavoriteRepository
     Optional<Favorite> findByMember_IdAndPhrase_Id(Long memberId, Long phraseId);
 
     List<Favorite> findByMember_Id(Long id);
+
+    @Modifying
+    @Query("DELETE FROM Favorite f WHERE f.phrase.id = :phraseId")
+    void deleteByPhraseId(Long phraseId);
 
     boolean existsByMember_IdAndPhrase_Id(Long memberId, Long phraseId);
 }

--- a/src/main/java/com/nexters/dailyphrase/favorite/implement/FavoriteCommandService.java
+++ b/src/main/java/com/nexters/dailyphrase/favorite/implement/FavoriteCommandService.java
@@ -28,6 +28,10 @@ public class FavoriteCommandService {
         favoriteRepository.delete(favorite);
     }
 
+    public void deleteByPhraseId(final Long id) {
+        favoriteRepository.deleteByPhraseId(id);
+    }
+
     public void deleteAllByIdInBatch(List<Long> favoriteIds) {
         favoriteRepository.deleteAllByIdInBatch(favoriteIds);
     }

--- a/src/main/java/com/nexters/dailyphrase/like/domain/repository/LikeRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/like/domain/repository/LikeRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.nexters.dailyphrase.like.domain.Like;
 
@@ -13,6 +15,10 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     List<Like> findByMember_Id(Long memberId);
 
     int countByPhrase_Id(Long id);
+
+    @Modifying
+    @Query("DELETE FROM Like l WHERE l.phrase.id = :phraseId")
+    void deleteByPhraseId(Long phraseId);
 
     boolean existsByMember_IdAndPhrase_Id(Long memberId, Long phraseId);
 }

--- a/src/main/java/com/nexters/dailyphrase/like/implement/LikeCommandService.java
+++ b/src/main/java/com/nexters/dailyphrase/like/implement/LikeCommandService.java
@@ -28,6 +28,10 @@ public class LikeCommandService {
         likeRepository.delete(like);
     }
 
+    public void deleteByPhraseId(final Long id) {
+        likeRepository.deleteByPhraseId(id);
+    }
+
     public void deleteAllByIdInBatch(List<Long> likeIds) {
         likeRepository.deleteAllByIdInBatch(likeIds);
     }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
- 좋아요, 즐겨찾기 데이터가 있는 게시글의 경우 좋아요와 즐겨찾기의 데이터 먼저 삭제하지 않으면 phrase 삭제가 되지 않는 오류 (외래키)가 발생하여 이를 수정합니다

## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
- 관리자 글 삭제 시 좋아요, 즐겨찾기 데이터를 글 삭제 이전에 삭제처리
- 삭제 응답에 게시글 id 추가

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

