### PR TITLE
fix/94: 이미지 URL 형식 변경

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/admin/business/AdminFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/business/AdminFacade.java
@@ -86,6 +86,8 @@ public class AdminFacade {
     //    }
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
+    @Value("https://kr.object.ncloudstorage.com")
+    private String endpoint;
 
     @Transactional
     public AdminResponseDTO.UploadImageFile uploadImageFile(final MultipartFile image)
@@ -108,7 +110,7 @@ public class AdminFacade {
                             .withCannedAcl(CannedAccessControlList.PublicRead));
         }
 
-        String storeFileUrl = amazonS3Client.getUrl(bucket, key).toString();
+        String storeFileUrl = endpoint+"/"+ bucket + "/" + key;
 
         return adminMapper.toUploadImageFile(storeFileUrl, image.getSize(), originalFilename);
     }

--- a/src/main/java/com/nexters/dailyphrase/admin/business/AdminFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/business/AdminFacade.java
@@ -86,7 +86,7 @@ public class AdminFacade {
     //    }
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
-    @Value("https://kr.object.ncloudstorage.com")
+    @Value("${cloud.aws.s3.endpoint}")
     private String endpoint;
 
     @Transactional

--- a/src/main/java/com/nexters/dailyphrase/admin/business/AdminFacade.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/business/AdminFacade.java
@@ -159,6 +159,8 @@ public class AdminFacade {
         PhraseImage updatedPhraseImage = updatedPhrase.getPhraseImage();
         updatedPhraseImage.setImageRatio(requestedPhraseImage.getImageRatio());
         updatedPhraseImage.setFileName(requestedPhraseImage.getFileName());
+        updatedPhraseImage.setImageUrl(requestedPhraseImage.getUrl());
+        updatedPhraseImage.setFileSize(requestedPhraseImage.getFileSize());
 
         return adminMapper.toModifyPhrase(updatedPhrase);
     }

--- a/src/main/java/com/nexters/dailyphrase/phraseimage/domain/PhraseImage.java
+++ b/src/main/java/com/nexters/dailyphrase/phraseimage/domain/PhraseImage.java
@@ -51,4 +51,12 @@ public class PhraseImage extends BaseDateTimeEntity {
     public void setImageRatio(String imageRatio) {
         this.imageRatio = imageRatio;
     }
+
+    public void setImageUrl(String imageUrl) {
+        this.url = imageUrl;
+    }
+
+    public void setFileSize(long filesize) {
+        this.fileSize = filesize;
+    }
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
http ssl 오류로, 현재 url 형식은 추가 보안설정 없이 이미지가 정상 조회되지 않습니다.
## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
- 이미지url 형식 변경
ㅇ   변경 전:  https://+버킷이름+.kr.object.ncloudstorage.com+FileName
       변경 후: https://kr.object.ncloudstorage.com/+버킷이름+FileName

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

