### PR TITLE
fix/99: 스케줄링 시간 보정(한국시각 9시, GMT 00시)

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/job/PhraseScheduler.java
+++ b/src/main/java/com/nexters/dailyphrase/job/PhraseScheduler.java
@@ -16,7 +16,7 @@ public class PhraseScheduler {
 
     private final PhraseRepository phraseRepository;
 
-    @Scheduled(cron = "0 0 8 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void publishScheduledPhrases() {
         phraseRepository.updateByIsPublishDate(LocalDate.now());


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
네이버 클라우드 서버 시간은 한국 표준시와 9시간 차이가 나므로, 스케줄링 시간을 수정합니다

## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
- 한국시각 오전 9시, GMT 00시로 수정

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

