### PR TITLE
Feature/106 : 글귀 상세조회 API 유저 데이터 적재

### DIFF
--- a/src/main/generated/com/nexters/dailyphrase/readhistory/domain/QReadHistory.java
+++ b/src/main/generated/com/nexters/dailyphrase/readhistory/domain/QReadHistory.java
@@ -1,0 +1,51 @@
+package com.nexters.dailyphrase.readhistory.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QReadHistory is a Querydsl query type for ReadHistory
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QReadHistory extends EntityPathBase<ReadHistory> {
+
+    private static final long serialVersionUID = 1968933288L;
+
+    public static final QReadHistory readHistory = new QReadHistory("readHistory");
+
+    public final com.nexters.dailyphrase.common.domain.QBaseDateTimeEntity _super = new com.nexters.dailyphrase.common.domain.QBaseDateTimeEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Long> memberId = createNumber("memberId", Long.class);
+
+    public final NumberPath<Long> phraseId = createNumber("phraseId", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final StringPath userAgent = createString("userAgent");
+
+    public QReadHistory(String variable) {
+        super(ReadHistory.class, forVariable(variable));
+    }
+
+    public QReadHistory(Path<? extends ReadHistory> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QReadHistory(PathMetadata metadata) {
+        super(ReadHistory.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseReadActionProcessor.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseReadActionProcessor.java
@@ -1,0 +1,35 @@
+package com.nexters.dailyphrase.phrase.business;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nexters.dailyphrase.phrase.implement.PhraseCommandAdapter;
+import com.nexters.dailyphrase.readhistory.business.ReadHistoryMapper;
+import com.nexters.dailyphrase.readhistory.domain.ReadHistory;
+import com.nexters.dailyphrase.readhistory.implement.ReadHistoryCommandAdapter;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PhraseReadActionProcessor {
+    private final Logger logger = LogManager.getLogger(PhraseReadActionProcessor.class);
+
+    private final PhraseCommandAdapter phraseCommandAdapter;
+    private final ReadHistoryCommandAdapter readHistoryCommandAdapter;
+    private final ReadHistoryMapper readHistoryMapper;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void processReadAction(final Long id, final Long memberId, final String userAgent) {
+        try {
+            phraseCommandAdapter.increaseViewCountById(id);
+            ReadHistory readHistory = readHistoryMapper.toReadHistory(memberId, id, userAgent);
+            readHistoryCommandAdapter.save(readHistory);
+        } catch (Exception e) {
+            logger.error("PhraseService) 조회수 증가 & 정보 기록 중 에러가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseService.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/business/PhraseService.java
@@ -7,7 +7,6 @@ import com.nexters.dailyphrase.common.utils.MemberUtils;
 import com.nexters.dailyphrase.favorite.implement.FavoriteQueryAdapter;
 import com.nexters.dailyphrase.like.implement.LikeQueryAdapter;
 import com.nexters.dailyphrase.phrase.domain.Phrase;
-import com.nexters.dailyphrase.phrase.implement.PhraseCommandAdapter;
 import com.nexters.dailyphrase.phrase.implement.PhraseQueryAdapter;
 import com.nexters.dailyphrase.phrase.presentation.dto.PhraseResponseDTO;
 
@@ -16,19 +15,20 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class PhraseService {
+
     private final PhraseQueryAdapter phraseQueryAdapter;
-    private final PhraseCommandAdapter phraseCommandAdapter;
     private final LikeQueryAdapter likeQueryAdapter;
     private final FavoriteQueryAdapter favoriteQueryAdapter;
     private final PhraseMapper phraseMapper;
+    private final PhraseReadActionProcessor processReadAction;
     private final MemberUtils memberUtils;
 
-    @Transactional
-    public PhraseResponseDTO.PhraseDetail getPhraseDetail(final Long id) {
-        phraseCommandAdapter.increaseViewCountById(id);
+    @Transactional(readOnly = true)
+    public PhraseResponseDTO.PhraseDetail getPhraseDetail(final Long id, final String userAgent) {
+        Long memberId = memberUtils.getCurrentMemberId();
+        processReadAction.processReadAction(id, memberId, userAgent);
         Phrase phrase = phraseQueryAdapter.findPublishPhraseById(id);
         int likeCount = likeQueryAdapter.countByPhraseId(id);
-        Long memberId = memberUtils.getCurrentMemberId();
         boolean isLike = likeQueryAdapter.existsByMemberIdAndPhraseId(memberId, id);
         boolean isFavorite = favoriteQueryAdapter.existsByMemberIdAndPhraseId(memberId, id);
         return phraseMapper.toPhraseDetail(phrase, likeCount, isLike, isFavorite);

--- a/src/main/java/com/nexters/dailyphrase/phrase/presentation/PhraseApi.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/presentation/PhraseApi.java
@@ -41,7 +41,9 @@ public class PhraseApi {
     @ApiErrorCodeExample(value = {PhraseErrorCode.class, GlobalErrorCode.class})
     @GetMapping("/{id}")
     public CommonResponse<PhraseResponseDTO.PhraseDetail> getPhraseDetail(
-            @PathVariable final Long id) {
-        return CommonResponse.onSuccess(phraseService.getPhraseDetail(id));
+            @PathVariable final Long id,
+            @RequestHeader(value = "User-Agent", required = false, defaultValue = "Unknown")
+                    final String userAgent) {
+        return CommonResponse.onSuccess(phraseService.getPhraseDetail(id, userAgent));
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/readhistory/business/ReadHistoryMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/readhistory/business/ReadHistoryMapper.java
@@ -1,0 +1,16 @@
+package com.nexters.dailyphrase.readhistory.business;
+
+import com.nexters.dailyphrase.common.annotation.Mapper;
+import com.nexters.dailyphrase.readhistory.domain.ReadHistory;
+
+@Mapper
+public class ReadHistoryMapper {
+    public ReadHistory toReadHistory(
+            final Long memberId, final Long phraseId, final String userAgent) {
+        return ReadHistory.builder()
+                .memberId(memberId)
+                .phraseId(phraseId)
+                .userAgent(userAgent)
+                .build();
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/readhistory/domain/ReadHistory.java
+++ b/src/main/java/com/nexters/dailyphrase/readhistory/domain/ReadHistory.java
@@ -1,0 +1,28 @@
+package com.nexters.dailyphrase.readhistory.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import com.nexters.dailyphrase.common.domain.BaseDateTimeEntity;
+
+import lombok.*;
+
+// NOTE - 로그성 데이터라서 member와 phrase는 간접 참조합니다.
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ReadHistory extends BaseDateTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    private Long phraseId;
+
+    private String userAgent;
+}

--- a/src/main/java/com/nexters/dailyphrase/readhistory/domain/repository/ReadHistoryRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/readhistory/domain/repository/ReadHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.nexters.dailyphrase.readhistory.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nexters.dailyphrase.readhistory.domain.ReadHistory;
+
+public interface ReadHistoryRepository extends JpaRepository<ReadHistory, Long> {}

--- a/src/main/java/com/nexters/dailyphrase/readhistory/implement/ReadHistoryCommandAdapter.java
+++ b/src/main/java/com/nexters/dailyphrase/readhistory/implement/ReadHistoryCommandAdapter.java
@@ -1,0 +1,17 @@
+package com.nexters.dailyphrase.readhistory.implement;
+
+import com.nexters.dailyphrase.common.annotation.Adapter;
+import com.nexters.dailyphrase.readhistory.domain.ReadHistory;
+import com.nexters.dailyphrase.readhistory.domain.repository.ReadHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Adapter
+@RequiredArgsConstructor
+public class ReadHistoryCommandAdapter {
+    private final ReadHistoryRepository readHistoryRepository;
+
+    public void save(final ReadHistory readHistory) {
+        readHistoryRepository.save(readHistory);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/readhistory/implement/ReadHistoryQueryAdapter.java
+++ b/src/main/java/com/nexters/dailyphrase/readhistory/implement/ReadHistoryQueryAdapter.java
@@ -1,0 +1,12 @@
+package com.nexters.dailyphrase.readhistory.implement;
+
+import com.nexters.dailyphrase.common.annotation.Adapter;
+import com.nexters.dailyphrase.readhistory.domain.repository.ReadHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Adapter
+@RequiredArgsConstructor
+public class ReadHistoryQueryAdapter {
+    private final ReadHistoryRepository readHistoryRepository;
+}


### PR DESCRIPTION
## 🚀 개요
카카오톡 단톡방 홍보로 유저가 얼마나 유입되는지 파악하기 위해 조회 기록을 남깁니다.

## 🔍 작업 내용
- 글귀 상세 조회 API) User Agent 헤더 포함 DB에 글귀 조회 데이터 기록
- ReadHistory) 어떤 유저(memberId)가 어떤 글귀(phraseId)를 어떤 에이전트(userAgent)로 조회했는지 기록
    - 비로그인 사용자의 경우 memberId는 0
    - 요청에 User-Agent Http 헤더가 없는 경우, userAgent는 Unknown

## 📝 논의사항


