### PR TITLE
Feature/110: 예약 발행 게시글 관련 FCM 알림 개선

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/admin/business/AdminService.java
+++ b/src/main/java/com/nexters/dailyphrase/admin/business/AdminService.java
@@ -152,7 +152,7 @@ public class AdminService {
         phraseImage.setPhrase(savedPhrase);
         phraseImageCommandAdapter.create(phraseImage);
 
-        if (lastAlarmDate == null || !lastAlarmDate.equals(currentDate)) // 알림은 하루에 한번만 전송
+        if ((lastAlarmDate == null || !lastAlarmDate.equals(currentDate))&& savedPhrase.getPublishDate() == null ) // 알림은 하루에 한번만 전송, 예약되지 않은 글만 실행
         {
             final String alarmBody = savedPhrase.getTitle();
             final String alarmPhraseId = savedPhrase.getId().toString();

--- a/src/main/java/com/nexters/dailyphrase/job/PhraseScheduler.java
+++ b/src/main/java/com/nexters/dailyphrase/job/PhraseScheduler.java
@@ -1,7 +1,12 @@
 package com.nexters.dailyphrase.job;
 
+import java.io.IOException;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
+import com.nexters.dailyphrase.notification.SendNotification;
+import com.nexters.dailyphrase.phrase.domain.Phrase;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,10 +20,21 @@ import lombok.RequiredArgsConstructor;
 public class PhraseScheduler {
 
     private final PhraseRepository phraseRepository;
+    private final SendNotification sendNotification;
 
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
-    public void publishScheduledPhrases() {
-        phraseRepository.updateByIsPublishDate(LocalDate.now());
+    public void publishScheduledPhrases() throws IOException {
+        LocalDate currentDate = LocalDate.now();
+        phraseRepository.updateByIsPublishDate(currentDate);
+
+        List<Phrase> todayPhrase = phraseRepository.findPhraseByPublishDate(currentDate);
+        if (!todayPhrase.isEmpty()) //오늘 예약된 글이 있을때만 알림 전송
+        {
+            Phrase NotificationPhrase =todayPhrase.get(0); // 오늘 업로드예정 글 중 1건만 전송
+            final String alarmBody =  NotificationPhrase.getTitle();
+            final String alarmPhraseId =  NotificationPhrase.getId().toString();
+            sendNotification.sendMessageTo(alarmBody, alarmPhraseId);
+        }
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/job/PhraseScheduler.java
+++ b/src/main/java/com/nexters/dailyphrase/job/PhraseScheduler.java
@@ -28,7 +28,7 @@ public class PhraseScheduler {
         LocalDate currentDate = LocalDate.now();
         phraseRepository.updateByIsPublishDate(currentDate);
 
-        List<Phrase> todayPhrase = phraseRepository.findPhraseByPublishDate(currentDate);
+        List<Phrase> todayPhrase = phraseRepository.findByPublishDate(currentDate);
         if (!todayPhrase.isEmpty()) //오늘 예약된 글이 있을때만 알림 전송
         {
             Phrase NotificationPhrase =todayPhrase.get(0); // 오늘 업로드예정 글 중 1건만 전송

--- a/src/main/java/com/nexters/dailyphrase/phrase/domain/repository/PhraseRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/domain/repository/PhraseRepository.java
@@ -19,9 +19,7 @@ public interface PhraseRepository extends JpaRepository<Phrase, Long>, PhraseCus
             "select p from Phrase p left join fetch p.phraseImage where p.id = :phraseId and p.isReserved = false")
     Optional<Phrase> findPublishPhraseById(Long phraseId);
 
-    @Query(
-            "select p from Phrase p where p.publishDate = :publishDate")
-    List<Phrase> findPhraseByPublishDate(LocalDate publishDate);
+    List<Phrase> findByPublishDate(LocalDate publishDate);
 
     @Modifying
     @Query("update Phrase p set p.viewCount = p.viewCount + 1 where p.id = :phraseId")

--- a/src/main/java/com/nexters/dailyphrase/phrase/domain/repository/PhraseRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/phrase/domain/repository/PhraseRepository.java
@@ -1,6 +1,7 @@
 package com.nexters.dailyphrase.phrase.domain.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,6 +18,10 @@ public interface PhraseRepository extends JpaRepository<Phrase, Long>, PhraseCus
     @Query(
             "select p from Phrase p left join fetch p.phraseImage where p.id = :phraseId and p.isReserved = false")
     Optional<Phrase> findPublishPhraseById(Long phraseId);
+
+    @Query(
+            "select p from Phrase p where p.publishDate = :publishDate")
+    List<Phrase> findPhraseByPublishDate(LocalDate publishDate);
 
     @Modifying
     @Query("update Phrase p set p.viewCount = p.viewCount + 1 where p.id = :phraseId")


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
예약된 글은 예약발행일에 알림이 가도록 개선합니다.
(변경 전) 4.23일로 예약된 글도 관리자 글귀 업로드 시점(예.4.21)에 알림 전송 
(변경 후) 4.23일로 예약된 글은 예약 발행일자(4.23일)에 알림 전송, 
               예약되지 않은 글은 기존과 같이 관리자 글귀 업로드 시점(예.4.21)에 알림 전송

## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
- 관리자 글귀 업로드 API 변경 
 ㅇ 예약되지 않은 글(publishDate가 null)만 게시글 업로드 시점에 알림을 보내도록 체크
- 예약 스케쥴 API 수정
 ㅇ 예약한 글귀를 업로드 해주는 스케쥴러 내에, 알림 송신 기능 추가
 ㅇ 오늘 예약된 글이 있으면, 알림 전송 
  * *오늘 예약된 글이 여러 건 이여도, 첫번째 글만 전송하여 하루에 1번만 보내도록 함

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
만약 오늘일자 예약글이 있는데, 예약없이 오늘일자로 또 글귀를 업로드 하는 경우 알림 2건이상 발송될수있습니다.. 
다만 그런경우는 거의 없을 것 같고 알림 2번 송신이 큰 이슈는 아닐 것 같아서 고려하지않았습니다.