### PR TITLE
Feature/117 : 경품 목록 조회 API

### DIFF
--- a/src/main/generated/com/nexters/dailyphrase/prize/domain/QPrize.java
+++ b/src/main/generated/com/nexters/dailyphrase/prize/domain/QPrize.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.PathMetadata;
 import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
@@ -17,12 +18,16 @@ public class QPrize extends EntityPathBase<Prize> {
 
     private static final long serialVersionUID = 1783440584L;
 
+    private static final PathInits INITS = PathInits.DIRECT2;
+
     public static final QPrize prize = new QPrize("prize");
 
     public final com.nexters.dailyphrase.common.domain.QBaseDateTimeEntity _super = new com.nexters.dailyphrase.common.domain.QBaseDateTimeEntity(this);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final QPrizeEvent event;
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
@@ -36,15 +41,24 @@ public class QPrize extends EntityPathBase<Prize> {
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 
     public QPrize(String variable) {
-        super(Prize.class, forVariable(variable));
+        this(Prize.class, forVariable(variable), INITS);
     }
 
     public QPrize(Path<? extends Prize> path) {
-        super(path.getType(), path.getMetadata());
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
     }
 
     public QPrize(PathMetadata metadata) {
-        super(Prize.class, metadata);
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPrize(PathMetadata metadata, PathInits inits) {
+        this(Prize.class, metadata, inits);
+    }
+
+    public QPrize(Class<? extends Prize> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.event = inits.isInitialized("event") ? new QPrizeEvent(forProperty("event")) : null;
     }
 
 }

--- a/src/main/generated/com/nexters/dailyphrase/prize/domain/QPrizeEntry.java
+++ b/src/main/generated/com/nexters/dailyphrase/prize/domain/QPrizeEntry.java
@@ -27,8 +27,6 @@ public class QPrizeEntry extends EntityPathBase<PrizeEntry> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
-    public final QPrizeEvent event;
-
     public final QPrize gift;
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
@@ -58,8 +56,7 @@ public class QPrizeEntry extends EntityPathBase<PrizeEntry> {
 
     public QPrizeEntry(Class<? extends PrizeEntry> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.event = inits.isInitialized("event") ? new QPrizeEvent(forProperty("event")) : null;
-        this.gift = inits.isInitialized("gift") ? new QPrize(forProperty("gift")) : null;
+        this.gift = inits.isInitialized("gift") ? new QPrize(forProperty("gift"), inits.get("gift")) : null;
     }
 
 }

--- a/src/main/generated/com/nexters/dailyphrase/prize/domain/QPrizeEvent.java
+++ b/src/main/generated/com/nexters/dailyphrase/prize/domain/QPrizeEvent.java
@@ -24,11 +24,13 @@ public class QPrizeEvent extends EntityPathBase<PrizeEvent> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
-    public final DateTimePath<java.time.LocalDateTime> end = createDateTime("end", java.time.LocalDateTime.class);
+    public final DateTimePath<java.time.LocalDateTime> endAt = createDateTime("endAt", java.time.LocalDateTime.class);
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    public final DateTimePath<java.time.LocalDateTime> start = createDateTime("start", java.time.LocalDateTime.class);
+    public final StringPath name = createString("name");
+
+    public final DateTimePath<java.time.LocalDateTime> startAt = createDateTime("startAt", java.time.LocalDateTime.class);
 
     public final EnumPath<com.nexters.dailyphrase.common.enums.PrizeEventStatus> status = createEnum("status", com.nexters.dailyphrase.common.enums.PrizeEventStatus.class);
 

--- a/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
         "/",
         "/swagger-ui/**",
         "/api/v1/phrases/**",
+        "/api/v1/events/{eventId}/prizes",
         "/api/v1/members/login/{socialType}",
         "/api/admin/login",
         "/api-docs/**"

--- a/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventMapper.java
@@ -1,0 +1,7 @@
+package com.nexters.dailyphrase.prize.business;
+
+import com.nexters.dailyphrase.common.annotation.Mapper;
+
+@Mapper
+public class PrizeEventMapper {
+}

--- a/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventMapper.java
@@ -3,5 +3,4 @@ package com.nexters.dailyphrase.prize.business;
 import com.nexters.dailyphrase.common.annotation.Mapper;
 
 @Mapper
-public class PrizeEventMapper {
-}
+public class PrizeEventMapper {}

--- a/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventService.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventService.java
@@ -1,10 +1,12 @@
 package com.nexters.dailyphrase.prize.business;
 
-import com.nexters.dailyphrase.prize.implement.PrizeQueryAdapter;
-import com.nexters.dailyphrase.prize.presentation.dto.PrizeEventResponseDTO;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.nexters.dailyphrase.prize.implement.PrizeQueryAdapter;
+import com.nexters.dailyphrase.prize.presentation.dto.PrizeEventResponseDTO;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventService.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventService.java
@@ -1,0 +1,18 @@
+package com.nexters.dailyphrase.prize.business;
+
+import com.nexters.dailyphrase.prize.implement.PrizeQueryAdapter;
+import com.nexters.dailyphrase.prize.presentation.dto.PrizeEventResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PrizeEventService {
+    private final PrizeQueryAdapter prizeQueryAdapter;
+
+    @Transactional(readOnly = true)
+    public PrizeEventResponseDTO.PrizeList getPrizeList(final Long eventId) {
+        return prizeQueryAdapter.findPrizeListDTO(eventId);
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/prize/domain/Prize.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/domain/Prize.java
@@ -22,6 +22,10 @@ public class Prize extends BaseDateTimeEntity {
     @Column(nullable = false)
     private String imageUrl;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private PrizeEvent event;
+
     @Column(nullable = false)
     private int requiredTicketCount;
 }

--- a/src/main/java/com/nexters/dailyphrase/prize/domain/PrizeEntry.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/domain/PrizeEntry.java
@@ -23,10 +23,6 @@ public class PrizeEntry extends BaseDateTimeEntity {
     @JoinColumn(name = "gift_id", nullable = false)
     private Prize gift;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id", nullable = false)
-    private PrizeEvent event;
-
     @Enumerated(EnumType.STRING)
     private PrizeEntryStatus status;
 }

--- a/src/main/java/com/nexters/dailyphrase/prize/domain/PrizeEvent.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/domain/PrizeEvent.java
@@ -19,11 +19,13 @@ public class PrizeEvent extends BaseDateTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private LocalDateTime start;
+    private String name;
 
     @Column(nullable = false)
-    private LocalDateTime end;
+    private LocalDateTime startAt;
+
+    @Column(nullable = false)
+    private LocalDateTime endAt;
 
     @Enumerated(EnumType.STRING)
     private PrizeEventStatus status;

--- a/src/main/java/com/nexters/dailyphrase/prize/domain/repository/PrizeCustomRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/domain/repository/PrizeCustomRepository.java
@@ -1,0 +1,7 @@
+package com.nexters.dailyphrase.prize.domain.repository;
+
+import com.nexters.dailyphrase.prize.presentation.dto.PrizeEventResponseDTO;
+
+public interface PrizeCustomRepository {
+    PrizeEventResponseDTO.PrizeList findPrizeListDTO(Long eventId);
+}

--- a/src/main/java/com/nexters/dailyphrase/prize/domain/repository/PrizeCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/domain/repository/PrizeCustomRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.nexters.dailyphrase.prize.domain.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.nexters.dailyphrase.common.utils.MemberUtils;
+import com.nexters.dailyphrase.prize.domain.QPrize;
+import com.nexters.dailyphrase.prize.domain.QPrizeEntry;
+import com.nexters.dailyphrase.prize.presentation.dto.PrizeEventResponseDTO;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PrizeCustomRepositoryImpl implements PrizeCustomRepository {
+    private final JPAQueryFactory queryFactory;
+    private final MemberUtils memberUtils;
+
+    @Override
+    public PrizeEventResponseDTO.PrizeList findPrizeListDTO(Long eventId) {
+
+        QPrize qPrize = QPrize.prize;
+        QPrizeEntry qPrizeEntry = QPrizeEntry.prizeEntry;
+
+        Long memberId = memberUtils.getCurrentMemberId();
+
+        List<PrizeEventResponseDTO.PrizeListItem> prizeListItems =
+                queryFactory
+                        .select(
+                                Projections.constructor(
+                                        PrizeEventResponseDTO.PrizeListItem.class,
+                                        qPrize.id,
+                                        qPrize.event.id,
+                                        qPrize.name,
+                                        qPrize.imageUrl,
+                                        qPrize.requiredTicketCount,
+                                        JPAExpressions.select(qPrizeEntry.id.count())
+                                                .from(qPrizeEntry)
+                                                .where(qPrizeEntry.gift.id.eq(qPrize.id)),
+                                        JPAExpressions.select(qPrizeEntry.id.count())
+                                                .from(qPrizeEntry)
+                                                .where(
+                                                        qPrizeEntry
+                                                                .gift
+                                                                .id
+                                                                .eq(qPrize.id)
+                                                                .and(
+                                                                        qPrizeEntry.memberId.eq(
+                                                                                memberId)))))
+                        .from(qPrize)
+                        .where(qPrize.event.id.eq(eventId))
+                        .fetch();
+
+        return PrizeEventResponseDTO.PrizeList.builder()
+                .total(prizeListItems.size())
+                .prizeList(prizeListItems)
+                .build();
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/prize/domain/repository/PrizeRepository.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/domain/repository/PrizeRepository.java
@@ -4,4 +4,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nexters.dailyphrase.prize.domain.Prize;
 
-public interface PrizeRepository extends JpaRepository<Prize, Long> {}
+public interface PrizeRepository extends JpaRepository<Prize, Long>, PrizeCustomRepository {}

--- a/src/main/java/com/nexters/dailyphrase/prize/implement/PrizeCommandAdapter.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/implement/PrizeCommandAdapter.java
@@ -1,0 +1,12 @@
+package com.nexters.dailyphrase.prize.implement;
+
+import com.nexters.dailyphrase.common.annotation.Adapter;
+import com.nexters.dailyphrase.prize.domain.repository.PrizeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Adapter
+@RequiredArgsConstructor
+public class PrizeCommandAdapter {
+    private final PrizeRepository prizeRepository;
+}

--- a/src/main/java/com/nexters/dailyphrase/prize/implement/PrizeQueryAdapter.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/implement/PrizeQueryAdapter.java
@@ -2,8 +2,8 @@ package com.nexters.dailyphrase.prize.implement;
 
 import com.nexters.dailyphrase.common.annotation.Adapter;
 import com.nexters.dailyphrase.prize.domain.repository.PrizeRepository;
-
 import com.nexters.dailyphrase.prize.presentation.dto.PrizeEventResponseDTO;
+
 import lombok.RequiredArgsConstructor;
 
 @Adapter
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 public class PrizeQueryAdapter {
     private final PrizeRepository prizeRepository;
 
-    public PrizeEventResponseDTO.PrizeList findPrizeListDTO(Long eventId) {
-        return null;
+    public PrizeEventResponseDTO.PrizeList findPrizeListDTO(final Long eventId) {
+        return prizeRepository.findPrizeListDTO(eventId);
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/prize/implement/PrizeQueryAdapter.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/implement/PrizeQueryAdapter.java
@@ -3,10 +3,15 @@ package com.nexters.dailyphrase.prize.implement;
 import com.nexters.dailyphrase.common.annotation.Adapter;
 import com.nexters.dailyphrase.prize.domain.repository.PrizeRepository;
 
+import com.nexters.dailyphrase.prize.presentation.dto.PrizeEventResponseDTO;
 import lombok.RequiredArgsConstructor;
 
 @Adapter
 @RequiredArgsConstructor
 public class PrizeQueryAdapter {
     private final PrizeRepository prizeRepository;
+
+    public PrizeEventResponseDTO.PrizeList findPrizeListDTO(Long eventId) {
+        return null;
+    }
 }

--- a/src/main/java/com/nexters/dailyphrase/prize/implement/PrizeQueryAdapter.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/implement/PrizeQueryAdapter.java
@@ -1,0 +1,12 @@
+package com.nexters.dailyphrase.prize.implement;
+
+import com.nexters.dailyphrase.common.annotation.Adapter;
+import com.nexters.dailyphrase.prize.domain.repository.PrizeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Adapter
+@RequiredArgsConstructor
+public class PrizeQueryAdapter {
+    private final PrizeRepository prizeRepository;
+}

--- a/src/main/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApi.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApi.java
@@ -1,6 +1,5 @@
 package com.nexters.dailyphrase.prize.presentation;
 
-import com.nexters.dailyphrase.prize.business.PrizeEventService;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -8,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nexters.dailyphrase.common.presentation.CommonResponse;
+import com.nexters.dailyphrase.prize.business.PrizeEventService;
 import com.nexters.dailyphrase.prize.presentation.dto.PrizeEventResponseDTO;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApi.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApi.java
@@ -1,5 +1,6 @@
 package com.nexters.dailyphrase.prize.presentation;
 
+import com.nexters.dailyphrase.prize.business.PrizeEventService;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,12 +21,14 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/events")
 public class PrizeEventApi {
 
+    private final PrizeEventService prizeEventService;
+
     @Operation(
             summary = "07-01 Event 🎁 특정 이벤트의 경품 목록 조회 Made By 성훈",
             description = "특정 이벤트의 경품 목록 조회 API입니다.")
     @GetMapping("/{eventId}/prizes")
     public CommonResponse<PrizeEventResponseDTO.PrizeList> getPrizeList(
-            @PathVariable Long eventId) {
-        return null;
+            @PathVariable final Long eventId) {
+        return CommonResponse.onSuccess(prizeEventService.getPrizeList(eventId));
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApi.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApi.java
@@ -1,0 +1,31 @@
+package com.nexters.dailyphrase.prize.presentation;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nexters.dailyphrase.common.presentation.CommonResponse;
+import com.nexters.dailyphrase.prize.presentation.dto.PrizeEventResponseDTO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "07-Event 🎁", description = "경품 응모 이벤트 관련 API")
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/events")
+public class PrizeEventApi {
+
+    @Operation(
+            summary = "07-01 Event 🎁 특정 이벤트의 경품 목록 조회 Made By 성훈",
+            description = "특정 이벤트의 경품 목록 조회 API입니다.")
+    @GetMapping("/{eventId}/prizes")
+    public CommonResponse<PrizeEventResponseDTO.PrizeList> getPrizeList(
+            @PathVariable Long eventId) {
+        return null;
+    }
+}

--- a/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventRequestDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventRequestDTO.java
@@ -1,0 +1,7 @@
+package com.nexters.dailyphrase.prize.presentation.dto;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PrizeEventRequestDTO {}

--- a/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventResponseDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventResponseDTO.java
@@ -18,8 +18,8 @@ public class PrizeEventResponseDTO {
         private String name;
         private String imageUrl;
         private int requiredTicketCount; // 필요한 응모권 개수
-        private int totalEntryCount; // 전체 응모수
-        @Builder.Default private int myEntryCount = 0; // 내 응모수
+        private long totalEntryCount; // 전체 응모수
+        @Builder.Default private long myEntryCount = 0; // 내 응모수
     }
 
     @Builder

--- a/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventResponseDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventResponseDTO.java
@@ -1,0 +1,33 @@
+package com.nexters.dailyphrase.prize.presentation.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PrizeEventResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PrizeListItem {
+        private Long prizeId;
+        private Long eventId;
+        private String name;
+        private String imageUrl;
+        private int requiredTicketCount; // 필요한 응모권 개수
+        private int totalEntryCount; // 전체 응모수
+        @Builder.Default private int myEntryCount = 0; // 내 응모수
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PrizeList {
+        private long total;
+        @Builder.Default private List<PrizeListItem> prizeList = new ArrayList<>();
+    }
+}

--- a/src/test/java/com/nexters/dailyphrase/phrase/business/PhraseServiceIntegrationTest.java
+++ b/src/test/java/com/nexters/dailyphrase/phrase/business/PhraseServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.nexters.dailyphrase.phrase.domain.Phrase;
@@ -33,6 +34,7 @@ class PhraseServiceIntegrationTest {
     final String uuid = "550e8400-e29b-41d4-a716-446655440000";
 
     @Test
+    @WithMockUser(username = "1")
     @DisplayName("글귀 상세조회 로직을 테스트합니다.")
     void 글귀_상세조회() {
         // given
@@ -45,7 +47,8 @@ class PhraseServiceIntegrationTest {
         phraseImageRepository.save(phraseImage);
 
         // when
-        PhraseResponseDTO.PhraseDetail phraseDetail = phraseService.getPhraseDetail(phraseId);
+        PhraseResponseDTO.PhraseDetail phraseDetail =
+                phraseService.getPhraseDetail(phraseId, "Unknown");
 
         // then
         assertEquals(title, phraseDetail.getTitle());
@@ -70,7 +73,7 @@ class PhraseServiceIntegrationTest {
             executorService.execute(
                     () -> {
                         try {
-                            phraseService.getPhraseDetail(phraseId);
+                            phraseService.getPhraseDetail(phraseId, "Unknown");
                         } finally {
                             latch.countDown();
                         }

--- a/src/test/java/com/nexters/dailyphrase/phrase/business/PhraseServiceIntegrationTest.java
+++ b/src/test/java/com/nexters/dailyphrase/phrase/business/PhraseServiceIntegrationTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.nexters.dailyphrase.phrase.domain.Phrase;
@@ -34,7 +33,6 @@ class PhraseServiceIntegrationTest {
     final String uuid = "550e8400-e29b-41d4-a716-446655440000";
 
     @Test
-    @WithMockUser(username = "1")
     @DisplayName("글귀 상세조회 로직을 테스트합니다.")
     void 글귀_상세조회() {
         // given

--- a/src/test/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApiTest.java
+++ b/src/test/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApiTest.java
@@ -1,0 +1,124 @@
+package com.nexters.dailyphrase.prize.presentation;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.nexters.dailyphrase.common.enums.PrizeEventStatus;
+import com.nexters.dailyphrase.member.domain.Member;
+import com.nexters.dailyphrase.member.domain.repository.MemberRepository;
+import com.nexters.dailyphrase.prize.domain.Prize;
+import com.nexters.dailyphrase.prize.domain.PrizeEntry;
+import com.nexters.dailyphrase.prize.domain.PrizeEvent;
+import com.nexters.dailyphrase.prize.domain.repository.PrizeEntryRepository;
+import com.nexters.dailyphrase.prize.domain.repository.PrizeEventRepository;
+import com.nexters.dailyphrase.prize.domain.repository.PrizeRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PrizeEventApiTest {
+    @Autowired private WebApplicationContext webApplicationContext;
+    @Autowired private PrizeEventRepository prizeEventRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private PrizeEntryRepository prizeEntryRepository;
+
+    @Autowired private PrizeRepository prizeRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken("1", null, Collections.emptyList());
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+
+    @Test
+    @DisplayName("경품 목록 조회 기능 테스트입니다.")
+    void 경품_목록_조회_테스트() throws Exception {
+        // given
+        Long eventId = 1L; // 테스트할 이벤트 ID
+        int prizeCount = 5; // 생성할 경품의 수
+        PrizeEvent prizeEvent =
+                PrizeEvent.builder()
+                        .id(eventId)
+                        .name("Sample Event")
+                        .startAt(LocalDateTime.now().minusDays(1))
+                        .endAt(LocalDateTime.now().plusDays(1))
+                        .status(PrizeEventStatus.ACTIVE)
+                        .build();
+        prizeEventRepository.save(prizeEvent); // 경품 이벤트 저장
+
+        Member testMember = Member.builder().id(1L).name("testuser").build();
+        memberRepository.save(testMember); // 테스트 멤버 저장
+
+        List<Prize> prizes =
+                IntStream.range(0, prizeCount)
+                        .mapToObj(
+                                i ->
+                                        Prize.builder()
+                                                .event(prizeEvent)
+                                                .name("Prize " + i)
+                                                .imageUrl("http://example.com/prize" + i + ".jpg")
+                                                .requiredTicketCount(10 * i)
+                                                .build())
+                        .collect(Collectors.toList());
+        prizeRepository.saveAll(prizes); // 경품들 저장
+
+        // 멤버가 일부 경품에 응모한 내역 생성
+        PrizeEntry prizeEntry =
+                PrizeEntry.builder().memberId(testMember.getId()).gift(prizes.get(0)).build();
+        prizeEntryRepository.save(prizeEntry);
+
+        PrizeEntry prizeEntry2 = PrizeEntry.builder().memberId(2L).gift(prizes.get(0)).build();
+        prizeEntryRepository.save(prizeEntry2);
+
+        // when & then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/api/v1/events/{eventId}/prizes", eventId)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.total").value(prizeCount))
+                .andExpect(jsonPath("$.result.prizeList", hasSize(prizeCount)))
+                .andExpect(jsonPath("$.result.prizeList[0].prizeId").isNotEmpty())
+                .andExpect(jsonPath("$.result.prizeList[0].name").value("Prize 0"))
+                .andExpect(
+                        jsonPath("$.result.prizeList[0].imageUrl")
+                                .value("http://example.com/prize0.jpg"))
+                .andExpect(jsonPath("$.result.prizeList[0].requiredTicketCount").value(0))
+                .andExpect(jsonPath("$.result.prizeList[0].totalEntryCount").value(2))
+                .andExpect(jsonPath("$.result.prizeList[0].myEntryCount").value(1)); // 응모한 내역 수 확인
+    }
+}


### PR DESCRIPTION
## 🚀 개요
경품 목록 조회 API를 작성했습니다.

## 🔍 작업 내용
- 경품 목록 조회 API
- H2 DB에서 end가 예약어인 관계로 PrizeEvent 테이블 필드명 일부 변경

## 📝 논의사항
특정 유저의 응모 횟수를 잘 가져오는 지 검증 하기 위해, 테스트 코드에서 SecurityContextHolder에 특정 멤버를 세팅하는 로직을 BeforeEach에 포함해서 테스트 했는데, 좀 더 나은 방법이 있을 것 같아서 나중에 변경해보겠습니다.
