### PR TITLE
ci: AWS CLI 설치 스텝 수정

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build -x test -Pprofile=dev
 
-      - name: Install AWS CLI
+      - name: Install or Update AWS CLI
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
-          sudo ./aws/install
+          sudo ./aws/install --update
 
       - name: Configure AWS CLI
         run: |


### PR DESCRIPTION
## 🚀 개요
AWS CLI를 설치하는 스텝에서 아래와 같은 에러가 떠서 Install or Update로 수정했습니다.
```
  inflating: aws/dist/docutils/writers/html4css1/html4css1.css  
  inflating: aws/dist/docutils/writers/odf_odt/styles.odt  
Found preexisting AWS CLI installation: /usr/local/aws-cli/v2/current. Please rerun install script with --update flag.
Error: Process completed with exit code 1.
```
