### PR TITLE
Ci/114 : ecr 로그인 커맨드 추가 in Deploy to EC2 instance 스텝

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -75,6 +75,7 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           port: 22
           script: |
+            aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ECR_REPOSITORY_URL }}
             docker pull ${{ secrets.AWS_ECR_REPOSITORY_URL }}:${{ github.sha }}
             docker stop dailyphrase-dev-api || true
             docker rm dailyphrase-dev-api || true


### PR DESCRIPTION
## 🚀 개요
ecr 로그인 커맨드 추가 in Deploy to EC2 instance 스텝
이전 에러 내용
```
err: Error response from daemon: Head "https://851725449592.dkr.ecr.***.amazonaws.com/v2/dailyphrase/manifests/ba26e3bd2914e779cd60a36871a40d4f01b566fb": no basic auth credentials
```
