### PR TITLE
Feature/146 : 활성 이벤트의 eventId 상수로 관리

### DIFF
--- a/src/main/java/com/nexters/dailyphrase/common/consts/DailyPhraseStatic.java
+++ b/src/main/java/com/nexters/dailyphrase/common/consts/DailyPhraseStatic.java
@@ -25,4 +25,5 @@ public class DailyPhraseStatic {
     public static final int INTERNAL_SERVER = 500;
 
     public static final int MAX_EVENT_TICKETS_PER_DAY = 10;
+    public static final Long CURRENT_ACTIVE_EVENT_ID = 1L;
 }

--- a/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
         "/",
         "/swagger-ui/**",
         "/api/v1/phrases/**",
-        "/api/v1/events/{eventId}/prizes",
+        "/api/v1/events/prizes",
         "/api/v1/events/kakaolink/callback",
         "/api/v1/members/login/{socialType}",
         "/api/v1/modals",

--- a/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventService.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventService.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.nexters.dailyphrase.common.consts.DailyPhraseStatic;
 import com.nexters.dailyphrase.common.enums.PrizeEventStatus;
 import com.nexters.dailyphrase.common.enums.PrizeTicketStatus;
 import com.nexters.dailyphrase.common.jwt.JwtTokenService;
@@ -49,7 +50,7 @@ public class PrizeEventService {
 
     @Transactional
     public void issuePrizeTicket(final KakaolinkCallbackRequestDTO request) {
-        Long eventId = request.getEventId();
+        final Long eventId = DailyPhraseStatic.CURRENT_ACTIVE_EVENT_ID;
         String accessToken = request.getAccessToken();
         AccessTokenInfo accessTokenInfo = jwtTokenService.parseAccessToken(accessToken);
         Long memberId = accessTokenInfo.getUserId();

--- a/src/main/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApi.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApi.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import com.nexters.dailyphrase.common.consts.DailyPhraseStatic;
 import com.nexters.dailyphrase.common.presentation.CommonResponse;
 import com.nexters.dailyphrase.common.validation.KakaoAppAdminKeyValidator;
 import com.nexters.dailyphrase.prize.business.PrizeEventService;
@@ -27,9 +28,9 @@ public class PrizeEventApi {
     @Operation(
             summary = "07-01 Event 🎁 특정 이벤트의 경품 목록 조회 Made By 성훈",
             description = "특정 이벤트의 경품 목록 조회 API입니다.")
-    @GetMapping("/{eventId}/prizes")
-    public CommonResponse<PrizeEventResponseDTO.PrizeList> getPrizeList(
-            @PathVariable final Long eventId) {
+    @GetMapping("/prizes")
+    public CommonResponse<PrizeEventResponseDTO.PrizeList> getPrizeList() {
+        final Long eventId = DailyPhraseStatic.CURRENT_ACTIVE_EVENT_ID;
         return CommonResponse.onSuccess(prizeEventService.getPrizeList(eventId));
     }
 

--- a/src/main/java/com/nexters/dailyphrase/share/presentation/dto/KakaolinkCallbackRequestDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/share/presentation/dto/KakaolinkCallbackRequestDTO.java
@@ -13,6 +13,5 @@ public class KakaolinkCallbackRequestDTO {
     private String hashChatId;
     private Long templateId;
     private String accessToken; // 자체 토큰
-    private Long eventId = 1L;
     //    private Map<String, Object> serverCallbackArgs;
 }


### PR DESCRIPTION
## 🚀 개요
API 연동의 복잡도를 줄이고자,
매번 단일 이벤트로 진행한다고 가정하고 진행중인 이벤트 정보는 백엔드 서버에서 관리합니다.

