### PR TITLE
Feature/166 : 경품 이벤트 API 연동 중 요청사항

### DIFF
--- a/src/main/generated/com/nexters/dailyphrase/prize/domain/QPrizeEvent.java
+++ b/src/main/generated/com/nexters/dailyphrase/prize/domain/QPrizeEvent.java
@@ -37,6 +37,8 @@ public class QPrizeEvent extends EntityPathBase<PrizeEvent> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 
+    public final DateTimePath<java.time.LocalDateTime> winnerAnnouncementAt = createDateTime("winnerAnnouncementAt", java.time.LocalDateTime.class);
+
     public QPrizeEvent(String variable) {
         super(PrizeEvent.class, forVariable(variable));
     }

--- a/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/dailyphrase/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
         "/",
         "/swagger-ui/**",
         "/api/v1/phrases/**",
+        "/api/v1/events/info",
         "/api/v1/events/prizes",
         "/api/v1/events/kakaolink/callback",
         "/api/v1/members/login/{socialType}",

--- a/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventMapper.java
@@ -35,8 +35,8 @@ public class PrizeEventMapper {
                 .prizeId(prizeId)
                 .memberId(memberId)
                 .status(status)
-                .messageTitle(status.getMessageTitle())
-                .messageDetail(status.getMessageDetail())
+                //                .messageTitle(status.getMessageTitle())
+                //                .messageDetail(status.getMessageDetail())
                 .phoneNumber(phoneNumber)
                 .build();
     }

--- a/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventMapper.java
@@ -3,6 +3,7 @@ package com.nexters.dailyphrase.prize.business;
 import com.nexters.dailyphrase.common.annotation.Mapper;
 import com.nexters.dailyphrase.common.enums.PrizeEntryStatus;
 import com.nexters.dailyphrase.common.enums.PrizeTicketStatus;
+import com.nexters.dailyphrase.prize.domain.PrizeEvent;
 import com.nexters.dailyphrase.prize.domain.PrizeTicket;
 import com.nexters.dailyphrase.prize.presentation.dto.PrizeEventResponseDTO;
 
@@ -34,6 +35,17 @@ public class PrizeEventMapper {
                 .memberId(memberId)
                 .prizeId(prizeId)
                 .phoneNumber(phoneNumber)
+                .build();
+    }
+
+    public PrizeEventResponseDTO.PrizeEventInfo toPrizeEventInfo(PrizeEvent prizeEvent) {
+        return PrizeEventResponseDTO.PrizeEventInfo.builder()
+                .eventId(prizeEvent.getId())
+                .name(prizeEvent.getName())
+                .eventStartDateTime(prizeEvent.getStartAt())
+                .eventEndDateTime(prizeEvent.getEndAt())
+                .eventWinnerAnnouncementDateTime(prizeEvent.getWinnerAnnouncementAt())
+                .status(prizeEvent.getStatus().getDescription())
                 .build();
     }
 }

--- a/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventMapper.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventMapper.java
@@ -1,8 +1,11 @@
 package com.nexters.dailyphrase.prize.business;
 
+import java.util.List;
+
 import com.nexters.dailyphrase.common.annotation.Mapper;
 import com.nexters.dailyphrase.common.enums.PrizeEntryStatus;
 import com.nexters.dailyphrase.common.enums.PrizeTicketStatus;
+import com.nexters.dailyphrase.prize.domain.PrizeEntry;
 import com.nexters.dailyphrase.prize.domain.PrizeEvent;
 import com.nexters.dailyphrase.prize.domain.PrizeTicket;
 import com.nexters.dailyphrase.prize.presentation.dto.PrizeEventResponseDTO;
@@ -19,13 +22,22 @@ public class PrizeEventMapper {
     }
 
     public PrizeEventResponseDTO.PrizeEntryResult toPrizeEntryResult(
-            Long memberId, Long prizeId, PrizeEntryStatus status) {
+            Long memberId, Long prizeId, List<PrizeEntry> prizeEntryList) {
+
+        PrizeEntryStatus status = PrizeEntryStatus.MISSED;
+        String phoneNumber = "";
+        if (!prizeEntryList.isEmpty()) {
+            status = PrizeEntryStatus.WINNING;
+            phoneNumber = prizeEntryList.get(0).getPhoneNumber();
+        }
+
         return PrizeEventResponseDTO.PrizeEntryResult.builder()
                 .prizeId(prizeId)
                 .memberId(memberId)
                 .status(status)
                 .messageTitle(status.getMessageTitle())
                 .messageDetail(status.getMessageDetail())
+                .phoneNumber(phoneNumber)
                 .build();
     }
 

--- a/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventService.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventService.java
@@ -40,6 +40,12 @@ public class PrizeEventService {
     private final MemberUtils memberUtils;
 
     @Transactional(readOnly = true)
+    public PrizeEventResponseDTO.PrizeEventInfo getPrizeEventInfo(final Long eventId) {
+        final PrizeEvent prizeEvent = prizeEventQueryAdapter.findById(eventId);
+        return prizeEventMapper.toPrizeEventInfo(prizeEvent);
+    }
+
+    @Transactional(readOnly = true)
     public PrizeEventResponseDTO.PrizeList getPrizeList(final Long eventId) {
         return prizeQueryAdapter.findPrizeListDTO(eventId);
     }

--- a/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventService.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/business/PrizeEventService.java
@@ -53,9 +53,12 @@ public class PrizeEventService {
     @Transactional(readOnly = true)
     public PrizeEventResponseDTO.PrizeEntryResult getPrizeEntryResult(final Long prizeId) {
         Long memberId = memberUtils.getCurrentMemberId();
-        // 특정 멤버가 특정 상품에 응모했는데 그 중 당첨 된 것이 있는지?
-        PrizeEntryStatus status = prizeEntryQueryAdapter.findWinningEntry(memberId, prizeId);
-        return prizeEventMapper.toPrizeEntryResult(memberId, prizeId, status);
+
+        List<PrizeEntry> winningPrizeEntryList =
+                prizeEntryQueryAdapter.findWinningEntryList(
+                        memberId, prizeId, PrizeEntryStatus.WINNING);
+
+        return prizeEventMapper.toPrizeEntryResult(memberId, prizeId, winningPrizeEntryList);
     }
 
     private boolean isValidEvent(final Long eventId) {

--- a/src/main/java/com/nexters/dailyphrase/prize/domain/PrizeEvent.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/domain/PrizeEvent.java
@@ -27,6 +27,9 @@ public class PrizeEvent extends BaseDateTimeEntity {
     @Column(nullable = false)
     private LocalDateTime endAt;
 
+    @Column(nullable = false)
+    private LocalDateTime winnerAnnouncementAt;
+
     @Enumerated(EnumType.STRING)
     private PrizeEventStatus status;
 }

--- a/src/main/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApi.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApi.java
@@ -28,7 +28,16 @@ public class PrizeEventApi {
     private final KakaoAppAdminKeyValidator kakaoAppAdminKeyValidator;
 
     @Operation(
-            summary = "07-01 Event 🎁 경품 응모 이벤트의 경품 목록 조회 Made By 성훈",
+            summary = "07-01 Event 🎁 경품 응모 이벤트의 이벤트 정보 조회 Made By 성훈",
+            description = "경품 응모 이벤트의 이벤트 정보 조회 API입니다.")
+    @GetMapping("/info")
+    public CommonResponse<PrizeEventResponseDTO.PrizeEventInfo> getPrizeEventInfo() {
+        final Long eventId = DailyPhraseStatic.CURRENT_ACTIVE_EVENT_ID;
+        return CommonResponse.onSuccess(prizeEventService.getPrizeEventInfo(eventId));
+    }
+
+    @Operation(
+            summary = "07-02 Event 🎁 경품 응모 이벤트의 경품 목록 조회 Made By 성훈",
             description = "경품 응모 이벤트의 경품 목록 조회 API입니다.")
     @GetMapping("/prizes")
     public CommonResponse<PrizeEventResponseDTO.PrizeList> getPrizeList() {
@@ -37,7 +46,7 @@ public class PrizeEventApi {
     }
 
     @Operation(
-            summary = "07-02 Event 🎁 경품 응모 이벤트의 경품 응모 결과 확인 Made By 성훈",
+            summary = "07-03 Event 🎁 경품 응모 이벤트의 경품 응모 결과 확인 Made By 성훈",
             description = "경품 응모 이벤트의 경품 응모 결과 확인 API입니다.")
     @GetMapping("/prizes/{prizeId}/entry-result")
     public CommonResponse<PrizeEventResponseDTO.PrizeEntryResult> getPrizeEntryResult(
@@ -46,7 +55,7 @@ public class PrizeEventApi {
     }
 
     @Operation(
-            summary = "07-03 Event 🎁 경품 응모 이벤트의 당첨자 연락처 입력 Made By 성훈",
+            summary = "07-04 Event 🎁 경품 응모 이벤트의 당첨자 연락처 입력 Made By 성훈",
             description = "경품 응모 이벤트의 당첨자 연락처 입력 API입니다.")
     @PostMapping("/prizes/{prizeId}/phone-number")
     public CommonResponse<PrizeEventResponseDTO.EnterPhoneNumber> enterPhoneNumber(
@@ -56,7 +65,7 @@ public class PrizeEventApi {
     }
 
     @Operation(
-            summary = "07-04 Event 🎁 경품 응모 이벤트의 응모권 발급용 카카오 콜백 Made By 성훈",
+            summary = "07-05 Event 🎁 경품 응모 이벤트의 응모권 발급용 카카오 콜백 Made By 성훈",
             description = "경품 응모 이벤트의 응모권 발급용 카카오 콜백입니다. (직접 호출 X)")
     @PostMapping("/kakaolink/callback")
     public ResponseEntity<String> handleKakaoLinkCallback(

--- a/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventResponseDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventResponseDTO.java
@@ -59,8 +59,9 @@ public class PrizeEventResponseDTO {
         private Long prizeId;
         private Long memberId;
         private PrizeEntryStatus status;
-        private String messageTitle;
-        private String messageDetail;
+        //        NOTE - 모달 안내 문구는 클라이언트에서 처리 (문구 변경가능성 X)
+        //        private String messageTitle;
+        //        private String messageDetail;
         private String phoneNumber;
     }
 

--- a/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventResponseDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventResponseDTO.java
@@ -61,6 +61,7 @@ public class PrizeEventResponseDTO {
         private PrizeEntryStatus status;
         private String messageTitle;
         private String messageDetail;
+        private String phoneNumber;
     }
 
     @Builder

--- a/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventResponseDTO.java
+++ b/src/main/java/com/nexters/dailyphrase/prize/presentation/dto/PrizeEventResponseDTO.java
@@ -72,4 +72,17 @@ public class PrizeEventResponseDTO {
         private Long memberId;
         private String phoneNumber;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PrizeEventInfo {
+        private Long eventId;
+        private String name;
+        private LocalDateTime eventStartDateTime;
+        private LocalDateTime eventEndDateTime;
+        private LocalDateTime eventWinnerAnnouncementDateTime;
+        private String status;
+    }
 }

--- a/src/test/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApiTest.java
+++ b/src/test/java/com/nexters/dailyphrase/prize/presentation/PrizeEventApiTest.java
@@ -75,6 +75,7 @@ class PrizeEventApiTest {
                         .name("Sample Event")
                         .startAt(LocalDateTime.now().minusDays(1))
                         .endAt(LocalDateTime.now().plusDays(1))
+                        .winnerAnnouncementAt(LocalDateTime.now().plusDays(2))
                         .status(PrizeEventStatus.ACTIVE)
                         .build();
         prizeEventRepository.save(prizeEvent); // 경품 이벤트 저장
@@ -91,6 +92,8 @@ class PrizeEventApiTest {
                                                 .name("Prize " + i)
                                                 .shortName("Short Prize" + i)
                                                 .imageUrl("http://example.com/prize" + i + ".jpg")
+                                                .bannerImageUrl("")
+                                                .welcomeImageUrl("")
                                                 .manufacturer("manufacturer" + i)
                                                 .requiredTicketCount(10 * i)
                                                 .build())


### PR DESCRIPTION
## 🚀 개요
API 연동과정에서 발생한 클라이언트 요청사항들을 반영했습니다.

## 🔍 작업 내용
- 당첨자 발표 날짜 필요 - PrizeEvent (이벤트 정보 조회 API)
- 당첨 결과 확인 API - 휴대폰 번호 입력한 경우, 응답에 포함

## 📝 논의사항
- 나의 정보 조회 (오늘 획득한 응모권 개수 등) API 분리 고민

